### PR TITLE
Add GitHub Action for testing the build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install required tools
+        run: sudo apt update && sudo apt install -y g++ curl
+
+      - name: Make build.sh executable
+        run: chmod +x ./build.sh
+
+      - name: Run build script
+        run: ./build.sh


### PR DESCRIPTION
`/usr/bin/g++` should be set instead of `/usr/bin/g++-14` as it's distro-specific and the pipeline will fail. More improvements for the build script will come later.