### PR TITLE
Improve build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,28 +1,49 @@
 #!/bin/bash
-# download and extract intel pin
+set -euo pipefail
+
 PIN_ARCHIVE="pin-external-3.31-98869-gfa6f126a8-gcc-linux"
 PIN_URL="https://software.intel.com/sites/landingpage/pintool/downloads/${PIN_ARCHIVE}.tar.gz"
+REQUIRED_GCC=14
 
-pushd ..
-
-if [ ! -d "$PIN_ARCHIVE" ]; then
-    curl "$PIN_URL" | tar zxf -
+if command -v g++-14 &>/dev/null; then
+    CXX=$(command -v g++-14)
+else
+    if command -v g++ &>/dev/null; then
+        CXX=$(command -v g++)
+        GPP_VERSION=$($CXX -dumpversion)
+        GPP_MAJOR_VERSION=${GPP_VERSION%%.*}
+        if [[ "$GPP_MAJOR_VERSION" -ne "$REQUIRED_GCC" ]]; then
+            echo "Error: Found $CXX version $GPP_VERSION; required version is $REQUIRED_GCC.*"
+            exit 1
+        fi
+    else
+        echo "Error: g++ 14.* not found in PATH."
+        exit 1
+    fi
 fi
-if [ ! -d "$PIN_ARCHIVE" ]; then
+echo "Using $CXX $GPP_VERSION"
+
+pushd .. > /dev/null
+
+if [[ ! -d "$PIN_ARCHIVE" ]]; then
+    echo "Downloading Intel Pin..."
+    curl -fsSL "$PIN_URL" | tar -xzf -
+fi
+
+if [[ ! -d "$PIN_ARCHIVE" ]]; then
     echo "Error: Failed to download or extract Intel Pin archive." >&2
     exit 1
 fi
 
-export PIN_ROOT=$(realpath `ls -d pin*`)
-popd
-# builds the custom library (pintool)
-export CXX=/usr/bin/g++-14
+PIN_ROOT=$(realpath `ls -d pin*`)
+export PIN_ROOT
+popd > /dev/null
+export CXX="$CXX"
 make
-echo "export PIN_ROOT=$PIN_ROOT" > env
-# build code coverage target example
-#pushd example && make && popd
-# run code coverage tool
-#$PIN_ROOT/pin -t ./obj-intel64/FuncTracer.so -- example/cov_sample 7 3
+echo "export PIN_ROOT=\"$PIN_ROOT\"" > env
 
-
-
+# Optional: Build and run the example
+# First you have to set PIN_ENV generated in `env`
+#
+# pushd example && make && popd
+# "$PIN_ROOT/pin" -t ./obj-intel64/FuncTracer.so -- example/cov_sample 7 3

--- a/env
+++ b/env
@@ -1,1 +1,0 @@
-export PIN_ROOT=/home/andrea/pin-external-3.31-98869-gfa6f126a8-gcc-linux


### PR DESCRIPTION
These changes make the script more relisient on different distributions where the `g++-14` binary might not be available. We still check for gcc version 14.