### PR TITLE
Address recursive instrumentation

### DIFF
--- a/cmd/funkoverage.go
+++ b/cmd/funkoverage.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const versionString = "0.6.2"
+const versionString = "0.6.3"
 
 // --- CLI ---
 

--- a/cmd/wrapunwrap.go
+++ b/cmd/wrapunwrap.go
@@ -294,6 +294,14 @@ PIN_TOOL="%s"
 LOG_DIR="%s"
 ORIGINAL_BINARY="%s"
 
+# Avoid Pin-in-Pin recursion: when an instrumented process exec's another
+# wrapped binary (e.g. tar -> bzip2), -follow_execv already attached Pin to
+# the child. Re-launching pin here would cause an arch_prctl assertion.
+if [ -n "$BINARYCOVERAGE_PIN_ACTIVE" ]; then
+    exec "$ORIGINAL_BINARY" "$@"
+fi
+export BINARYCOVERAGE_PIN_ACTIVE=1
+
 mkdir -m 0777 -p "$LOG_DIR"
 
 binary_name=$(basename "$0")


### PR DESCRIPTION
● Pin-in-Pin recursion via -follow_execv

  When a wrapped binary execs another wrapped binary (e.g. tar -cjvf → bzip2), the outer Pin follows
   the exec into the child's bash wrapper. The wrapper then exec's a second pin process, so Pin ends
   up instrumenting Pin. This trips the assertion:

  ExecuteSysArchPrctl: *(ADDRINT*)threadDescriptor == GetReg(REG_SEG_FS_BASE).value()

  The inner Pin sets up TLS via arch_prctl(ARCH_SET_FS, …), but the outer Pin's tracked FS base no
  longer matches the thread descriptor — child dies, parent reports Child returned status 127.

  Fix: wrapper sets BINARYCOVERAGE_PIN_ACTIVE=1 before exec'ing pin. On re-entry, if the var is
  already set, exec the original binary directly — the outer Pin keeps instrumenting via
  -follow_execv.
