### PR TITLE
Improve result templates

### DIFF
--- a/cmd/templates/aggregate.html
+++ b/cmd/templates/aggregate.html
@@ -45,6 +45,7 @@
         }
 
         .bar {
+            position: relative;
             height: 18px;
             background: #efefef;
             border-radius: 9px;
@@ -54,11 +55,18 @@
         .bar-inner {
             background: #30ba78;
             height: 100%;
-            color: #0c322c;
+        }
+
+        .bar-label {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
             text-align: center;
+            line-height: 18px;
             font-size: 0.9em;
             font-weight: bold;
-            line-height: 18px;
+            color: #0c322c;
         }
 
         tr:nth-child(even) {
@@ -86,6 +94,8 @@
             }
             .bar-inner {
                 background: #008657;
+            }
+            .bar-label {
                 color: #efefef;
             }
             th {
@@ -130,9 +140,8 @@
                     <td>{{.CalledCount}}</td>
                     <td>
                         <div class="bar">
-                            <div class="bar-inner" style="width: {{printf " %.1f" .CoveragePct}}%">
-                                {{printf "%.1f" .CoveragePct}}%
-                            </div>
+                            <div class="bar-inner" style="width: {{printf "%.1f" .CoveragePct}}%"></div>
+                            <span class="bar-label">{{printf "%.1f" .CoveragePct}}%</span>
                         </div>
                     </td>
                 </tr>

--- a/cmd/templates/aggregate.html
+++ b/cmd/templates/aggregate.html
@@ -30,12 +30,11 @@
         th,
         td {
             padding: 0.7em 1em;
-            border-bottom: 1px solid #ddd;
             text-align: left;
         }
 
         th {
-            background: #f4f4f4;
+            background: #efefef;
             cursor: pointer;
             user-select: none;
         }
@@ -70,7 +69,7 @@
         }
 
         tr:nth-child(even) {
-            background-color: #f9f9f9;
+            background-color: #fafafa;
         }
 
         th.sort-asc::after {

--- a/cmd/templates/detailed.html
+++ b/cmd/templates/detailed.html
@@ -61,8 +61,6 @@
         }
 
         .function-list li {
-            padding: 0.6em;
-            border-radius: 5px;
             font-family: monospace;
             white-space: nowrap;
             overflow: hidden;
@@ -75,6 +73,13 @@
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
         }
 
+        .called,
+        .uncalled {
+            padding: 0.2em 0.5em;
+            border-radius: 5px;
+            margin-right: 0.5em;
+        }
+
         .called {
             background: #d4edda;
             color: #025937;
@@ -85,6 +90,12 @@
             background: #f8d7da;
             color: #8e2810;
             border-left: 5px solid #ff5a2b;
+        }
+
+        .function-list li.called,
+        .function-list li.uncalled {
+            padding: 0.6em;
+            margin-right: 0;
         }
 
         details summary {

--- a/cmd/templates/detailed.html
+++ b/cmd/templates/detailed.html
@@ -87,6 +87,34 @@
             border-left: 5px solid #ff5a2b;
         }
 
+        details summary {
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            list-style: none;
+        }
+
+        details summary::-webkit-details-marker {
+            display: none;
+        }
+
+        details summary::before {
+            content: "▶";
+            margin-right: 0.5em;
+            font-size: 0.85em;
+            transition: transform 0.2s;
+            flex-shrink: 0;
+        }
+
+        details[open] summary::before {
+            transform: rotate(90deg);
+        }
+
+        details summary h2 {
+            display: inline;
+            margin: 0;
+        }
+
         @media (prefers-color-scheme: dark) {
             body {
                 background: #3e3e3e;
@@ -100,6 +128,9 @@
                 border-color: #525252;
             }
             .summary .percentage {
+                color: #efefef;
+            }
+            details summary h2 {
                 color: #efefef;
             }
             .progress-bar {

--- a/cmd/templates/detailed.html
+++ b/cmd/templates/detailed.html
@@ -29,27 +29,37 @@
             border: 1px solid #ddd;
         }
 
-        .summary .percentage {
-            font-size: 1.8em;
-            font-weight: bold;
-            color: #0c322c;
+        .progress-bar-wrap {
+            display: flex;
+            align-items: center;
+            gap: 0.75em;
+            margin-top: 1em;
         }
 
         .progress-bar {
+            position: relative;
             background: #e9ecef;
             border-radius: 50px;
             overflow: hidden;
-            height: 30px;
-            margin-top: 1em;
+            height: 25px;
+            flex: 1;
         }
 
         .progress-bar-inner {
             background: #30ba78;
             height: 100%;
-            color: #fff, text-align: center;
-            line-height: 30px;
-            font-weight: bold;
             transition: width 0.5s;
+        }
+
+        .progress-bar-label {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            text-align: center;
+            line-height: 25px;
+            font-weight: bold;
+            color: #0c322c;
         }
 
         .function-list {
@@ -138,9 +148,6 @@
                 background: #1d1d1d;
                 border-color: #525252;
             }
-            .summary .percentage {
-                color: #efefef;
-            }
             details summary h2 {
                 color: #efefef;
             }
@@ -149,6 +156,9 @@
             }
             .progress-bar-inner {
                 background: #008657;
+            }
+            .progress-bar-label {
+                color: #efefef;
             }
             .called {
                 background: #0c322c;
@@ -172,10 +182,12 @@
             <p><strong>Total Functions:</strong> {{.TotalCount}}</p>
             <p><strong>Called Functions:</strong> {{.CalledCount}}</p>
             <p><strong>Uncalled Functions:</strong> {{.UncalledCount}}</p>
-            <p class="percentage">Coverage: {{printf "%.1f" .CoveragePercentage}}%</p>
-            <div class="progress-bar">
-                <div class="progress-bar-inner" style="width: {{.CoveragePercentage}}%">{{printf "%.2f"
-                    .CoveragePercentage}}%</div>
+            <div class="progress-bar-wrap">
+                <strong>Coverage:</strong>
+                <div class="progress-bar">
+                    <div class="progress-bar-inner" style="width: {{.CoveragePercentage}}%"></div>
+                    <span class="progress-bar-label">{{printf "%.1f" .CoveragePercentage}}%</span>
+                </div>
             </div>
         </div>
         <details>


### PR DESCRIPTION
### 1. The arrow in "Function Details" is now inline and has a neat transition

<img width="305" height="85" alt="image" src="https://github.com/user-attachments/assets/82f0f534-03cc-4249-88cb-4b7e457ae57b" />

### 2. Coverage percentage in progress bars is now centered

<img width="163" height="135" alt="image" src="https://github.com/user-attachments/assets/4e5564d8-d80e-4917-9311-9d552202e3d5" />

### 3. Labels share unified styles

<img width="464" height="100" alt="image" src="https://github.com/user-attachments/assets/e9cf1ffe-ae2d-4023-be6a-f14952c109cf" />

### 4. Duplicate total coverage percentage has been merged into one line

<img width="911" height="225" alt="image" src="https://github.com/user-attachments/assets/9747a087-2f74-4fd7-8905-2c1554898690" />

### 5. Border in results table, which has been causing ugly contrast issues, is now removed

<img width="916" height="387" alt="image" src="https://github.com/user-attachments/assets/67367be9-fc67-45aa-908f-abbfeb3b6450" />
