### PR TITLE
Dedup enumerated functions by address; add gzip E2E test

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -238,6 +238,7 @@ func externalDebugPath(binPath string) string {
 
 func enumerateDWARF(dwarfData *dwarf.Data, filter *FuncFilter) ([]string, error) {
 	seen := make(map[string]struct{})
+	seenAddr := make(map[uint64]struct{})
 	var funcs []string
 
 	reader := dwarfData.Reader()
@@ -254,7 +255,8 @@ func enumerateDWARF(dwarfData *dwarf.Data, filter *FuncFilter) ([]string, error)
 			continue
 		}
 		// Skip abstract origins without an address (inlined-only entries)
-		if entry.Val(dwarf.AttrLowpc) == nil {
+		lowpc, ok := entry.Val(dwarf.AttrLowpc).(uint64)
+		if !ok {
 			continue
 		}
 
@@ -268,9 +270,18 @@ func enumerateDWARF(dwarfData *dwarf.Data, filter *FuncFilter) ([]string, error)
 			continue
 		}
 
+		// Itanium ABI complete-object/base-object ctor-dtor pairs (C1/C2,
+		// D1/D2) are distinct DIEs that alias the same low_pc whenever the
+		// class has no virtual bases. Dedup by address, not name (see the
+		// matching comment in enumerateSymtab).
+		if _, dup := seenAddr[lowpc]; dup {
+			continue
+		}
+
 		// Keep the raw (mangled) name. uprobe attach resolves it against
 		// the ELF symbol table directly; demangling happens at output time.
 		if acceptFunc(seen, raw, filter) {
+			seenAddr[lowpc] = struct{}{}
 			funcs = append(funcs, raw)
 		}
 	}
@@ -287,6 +298,7 @@ func enumerateSymtab(f *elf.File, filter *FuncFilter) ([]string, error) {
 		}
 	}
 	seen := make(map[string]struct{})
+	seenAddr := make(map[uint64]struct{})
 	var funcs []string
 	for _, sym := range symbols {
 		if elf.ST_TYPE(sym.Info) != elf.STT_FUNC {
@@ -301,7 +313,17 @@ func enumerateSymtab(f *elf.File, filter *FuncFilter) ([]string, error) {
 		if sym.Size == 0 {
 			continue
 		}
+		// Itanium ABI complete-object/base-object ctor-dtor pairs (C1/C2,
+		// D1/D2) are distinct symbols that alias the same address whenever
+		// the class has no virtual bases. Dedup by address, not name, so
+		// they count once instead of double-attaching and double-counting —
+		// this is safe even for virtual-base classes, where C1/C2 genuinely
+		// compile to different code at different addresses.
+		if _, dup := seenAddr[sym.Value]; dup {
+			continue
+		}
 		if acceptFunc(seen, sym.Name, filter) {
+			seenAddr[sym.Value] = struct{}{}
 			funcs = append(funcs, sym.Name)
 		}
 	}

--- a/tests/e2e/test_gzip.sh
+++ b/tests/e2e/test_gzip.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# E2E test: funkoverage coverage of gzip
+# Tests basic shim lifecycle: install, trace, report, uninstall.
+# gunzip/zcat are shell wrappers around the gzip binary (not separate ELF
+# binaries), so instrumenting gzip alone covers all three entry points.
+# Run as root on openSUSE with funkoverage in PATH.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib_test_helpers.sh"
+
+BINARY=""
+WORKDIR=""
+
+cleanup() {
+    [[ -n "$BINARY" ]] && funkoverage uninstall "$BINARY" 2>/dev/null || true
+    [[ -n "$WORKDIR" ]] && rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# --- Prerequisites ---
+header "Prerequisites"
+require_root
+require_funkoverage
+ensure_packages gzip gzip-debuginfo
+
+BINARY=$(which gzip)
+require_debug_symbols "$BINARY"
+pass "gzip with debug symbols"
+
+# --- Setup ---
+header "Setup"
+WORKDIR=$(mktemp -d /tmp/funkoverage_gzip_XXXX)
+clean_coverage_data
+install_shim --no-libs "$BINARY"
+pass "Shim installed"
+
+# --- Exercise ---
+header "Exercising gzip"
+cd "$WORKDIR"
+mkdir -p subdir
+
+seq 1 50000 > numbers.txt
+{ yes "the quick brown fox jumps over the lazy dog" || true; } | head -20000 > repetitive.txt
+head -c 200000 /dev/urandom | base64 > random.txt
+echo "hello world" > subdir/small.txt
+
+gzip -k numbers.txt
+[[ -f numbers.txt && -f numbers.txt.gz ]] || fail "keep original failed"
+pass "compress + keep original (-k)"
+
+cp repetitive.txt level1.txt && gzip -1 level1.txt
+cp repetitive.txt level9.txt && gzip -9 level9.txt
+[[ -f level1.txt.gz && -f level9.txt.gz ]] || fail "compression levels failed"
+pass "compression level extremes (-1, -9)"
+
+gzip -t numbers.txt.gz
+pass "integrity test (-t)"
+
+gzip -l numbers.txt.gz level1.txt.gz >/dev/null
+gzip -lv numbers.txt.gz level1.txt.gz >/dev/null
+pass "list info (-l, -lv)"
+
+cp numbers.txt dkeep.txt && gzip -k dkeep.txt && rm dkeep.txt
+gzip -dk dkeep.txt.gz
+[[ -f dkeep.txt && -f dkeep.txt.gz ]] || fail "decompress keep failed"
+pass "decompress keep (-dk)"
+
+cp numbers.txt plain.txt && gzip plain.txt && gzip -d plain.txt.gz
+[[ -f plain.txt && ! -f plain.txt.gz ]] || fail "plain decompress failed"
+pass "plain decompress (-d)"
+
+gzip -c random.txt > random_stdout.gz
+gzip -dc random_stdout.gz > /dev/null
+pass "stdout mode (-c compress + decompress)"
+
+gunzip -k level9.txt.gz
+[[ -f level9.txt ]] || fail "gunzip wrapper failed"
+pass "gunzip wrapper script"
+
+zcat random_stdout.gz > /dev/null
+pass "zcat wrapper script"
+
+RESULT=$(cat repetitive.txt | gzip -c | gunzip -c)
+[[ "$RESULT" == "$(cat repetitive.txt)" ]] || fail "stdin/stdout pipe roundtrip"
+pass "stdin/stdout pipe roundtrip"
+
+gzip -r subdir
+[[ -f subdir/small.txt.gz ]] || fail "recursive compression failed"
+pass "recursive directory compression (-r)"
+
+for i in 1 2 3; do echo "multi $i" > multi_$i.txt; done
+gzip multi_1.txt multi_2.txt multi_3.txt
+[[ -f multi_1.txt.gz && -f multi_2.txt.gz && -f multi_3.txt.gz ]] || fail "multi-file"
+pass "multi-file compress"
+
+echo "overwrite" > force.txt
+gzip -k force.txt
+echo "new content" > force.txt
+gzip -f force.txt
+pass "force overwrite (-f)"
+
+echo "verbose" > verbose.txt
+gzip -v verbose.txt
+gzip -dv verbose.txt.gz
+pass "verbose compress/decompress (-v)"
+
+echo "best" > best.txt
+gzip --best best.txt
+gunzip best.txt.gz
+echo "noname" > noname.txt
+gzip --no-name noname.txt
+gunzip noname.txt.gz
+pass "--best / --no-name flags"
+
+gzip --help 2>&1 | grep -q "gzip" || fail "help text missing"
+gzip --version >/dev/null
+pass "help/version"
+
+# --- Report ---
+header "Coverage report"
+REPORT_DIR=$(generate_report)
+assert_min_called "*gzip*" 20
+remove_report_dir "$REPORT_DIR"
+
+# --- Uninstall ---
+header "Uninstall"
+uninstall_and_verify "$BINARY"
+BINARY="" # prevent double-uninstall in trap
+
+echo ""
+echo -e "${GREEN}ALL TESTS PASSED${NC} (gzip)"


### PR DESCRIPTION
## Summary
- Dedup enumerated functions by ELF symbol **address**, not just (demangled) name, in both `enumerateSymtab` and `enumerateDWARF` (`cmd/enumerate.go`). Itanium ABI complete-object/base-object ctor/dtor pairs (`C1`/`C2`, `D1`/`D2`) are distinct symbols that alias the same address for any class without virtual bases — name-only dedup let both through, doubling uprobe attachments and producing duplicate `FUNC`/`CALLED` lines in the raw logs. Verified on `tests/sample`: `_functions.log` 520→458 raw lines, `_called.log` 480→419, with `report`'s totals unchanged (458 found / 419 called / 91.48%) since it already deduped downstream by name.
- Add `tests/e2e/test_gzip.sh`: a real-world functional test instrumenting the system `/usr/bin/gzip` and exercising compress/decompress from both ends (levels, integrity test, list, keep/force, stdout mode, recursive, multi-file, verbose, `--best`/`--no-name`) plus the `gunzip`/`zcat` shell wrappers and a stdin/stdout pipe roundtrip. Follows the existing `test_bzip2.sh` convention (`lib_test_helpers.sh`, `assert_min_called`).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass locally
- [x] Verified the dedup fix on the VM: rebuilt, reran `tests/sample --all`, confirmed raw log line counts drop as expected with report totals unchanged
- [x] Ran `tests/e2e/test_gzip.sh` end-to-end as root on a real openSUSE VM against the real `/usr/bin/gzip` (with `gzip-debuginfo` installed) — all assertions pass, coverage threshold met