### PR TITLE
fix: scope IsSystemLib's noisy-dlopen libs to runtime rediscovery only

### DIFF
--- a/cmd/shim_binary/tracer.go
+++ b/cmd/shim_binary/tracer.go
@@ -534,8 +534,8 @@ func (t *Tracer) handleDynamicLoad() {
 			continue
 		}
 
-		// Also skip system libraries to keep trace size reasonable
-		if funkutil.IsSystemLib(lib) {
+		// Also skip system/noisy dlopen libraries to keep trace size reasonable
+		if funkutil.IsNoisyDlopenLib(lib) {
 			continue
 		}
 

--- a/internal/funkutil/funkutil.go
+++ b/internal/funkutil/funkutil.go
@@ -63,23 +63,42 @@ func FuncIsRelevant(name string) bool {
 	return true
 }
 
-// systemLibRe matches glibc/runtime/system libraries that are never useful
-// wildcard-trace targets: each carries thousands of symbols, so attaching
-// uprobes to all of them blows past attach timeouts and rarely yields
-// meaningful coverage for the target program. Shared between install-time
-// ldd-based enumeration (cmd) and runtime dlopen JIT discovery
-// (cmd/shim_binary), which both want the same "not worth it" list.
+// coreSystemLibRe matches glibc/ld.so-family runtime libraries: never a
+// useful trace target anywhere, at install time or runtime, since they
+// carry no application code. Shared between install-time ldd-based
+// enumeration (cmd) and runtime dlopen JIT discovery (cmd/shim_binary).
 //
 // libstdc\+\+ is matched as its own alternative, outside the shared trailing
 // \b: "+" is not a word character, so a \b immediately after it can never
 // match a following "." (both sides non-word) — under the combined pattern
 // this alternative could never actually match a real "libstdc++.so*" path.
-var systemLibRe = regexp.MustCompile(`(?i)(?:libc|libm|libpthread|librt|libdl|libthread_db|ld-linux|libgcc_s|libglib|libgobject|libgthread|libgio|libcap|libattr|libpcre|libselinux|libmount|libblkid|libuuid|libpam|libaudit|libdbus|libsystemd|libudev|libresolv|libnsl|libutil|libcrypt|libanl)\b|libstdc\+\+`)
+var coreSystemLibRe = regexp.MustCompile(`(?i)(?:libc|libm|libpthread|librt|libdl|libthread_db|ld-linux|libgcc_s|libresolv|libnsl|libutil|libcrypt|libanl)\b|libstdc\+\+`)
 
-// IsSystemLib reports whether path names a system/runtime library that
-// install-time enumeration and runtime dlopen discovery should both skip.
+// noisyDlopenLibRe matches additional libraries that carry thousands of
+// symbols and are common dlopen() targets (NSS/PAM/D-Bus modules, systemd,
+// SELinux, the glib/gobject stack, ...). These are only skipped for
+// *runtime* dlopen rediscovery, which just wants to avoid the attach-time
+// cost of wildcard-tracing something bulky and dynamically loaded — they
+// are NOT skipped at install time: a binary that directly links libselinux
+// or libsystemd (an ordinary ldd dependency) should still get those
+// functions statically enumerated and traced like any other dependency.
+var noisyDlopenLibRe = regexp.MustCompile(`(?i)(?:libglib|libgobject|libgthread|libgio|libcap|libattr|libpcre|libselinux|libmount|libblkid|libuuid|libpam|libaudit|libdbus|libsystemd|libudev)\b`)
+
+// IsSystemLib reports whether path names a glibc/ld.so-family library that
+// is never a useful trace target — used by install-time ldd-based
+// enumeration to skip pure runtime libraries while still tracing ordinary
+// application dependencies.
 func IsSystemLib(path string) bool {
-	return systemLibRe.MatchString(filepath.Base(path))
+	return coreSystemLibRe.MatchString(filepath.Base(path))
+}
+
+// IsNoisyDlopenLib reports whether path names a library that runtime dlopen
+// rediscovery should skip in addition to IsSystemLib: bulky, commonly
+// dlopen'd libraries that are worth tracing when directly linked (see
+// IsSystemLib) but not worth re-instrumenting every time they're dlopen'd.
+func IsNoisyDlopenLib(path string) bool {
+	base := filepath.Base(path)
+	return coreSystemLibRe.MatchString(base) || noisyDlopenLibRe.MatchString(base)
 }
 
 // writeJSON marshals v to path. An empty value (per isEmpty) deletes the file.

--- a/internal/funkutil/funkutil_test.go
+++ b/internal/funkutil/funkutil_test.go
@@ -82,10 +82,46 @@ func TestIsSystemLib(t *testing.T) {
 		{"/opt/myapp/libplugin.so", false},
 		{"./libplugin.so", false},
 		{"/usr/lib64/libcustomthing.so.1", false},
+		// Direct ldd dependencies of these are ordinary, meaningful trace
+		// targets at install time — only IsNoisyDlopenLib skips them.
+		{"/usr/lib64/libselinux.so.1", false},
+		{"/usr/lib64/libsystemd.so.0", false},
+		{"/usr/lib64/libpam.so.0", false},
 	}
 	for _, c := range cases {
 		if got := IsSystemLib(c.path); got != c.want {
 			t.Errorf("IsSystemLib(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestIsNoisyDlopenLib(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Everything IsSystemLib already covers must still be skipped.
+		{"/lib64/libc.so.6", true},
+		{"/lib64/libstdc++.so.6", true},
+		// Plus the bulky/common dlopen targets install-time no longer skips.
+		{"/usr/lib64/libselinux.so.1", true},
+		{"/usr/lib64/libsystemd.so.0", true},
+		{"/usr/lib64/libpam.so.0", true},
+		{"/usr/lib64/libaudit.so.1", true},
+		{"/usr/lib64/libdbus-1.so.3", true},
+		{"/usr/lib64/libudev.so.1", true},
+		{"/usr/lib64/libmount.so.1", true},
+		{"/usr/lib64/libblkid.so.1", true},
+		{"/usr/lib64/libuuid.so.1", true},
+		{"/usr/lib64/libglib-2.0.so.0", true},
+		// Ordinary application libraries are still traced.
+		{"/usr/lib64/libssl.so.3", false},
+		{"/usr/lib64/libcurl.so.4", false},
+		{"/opt/myapp/libplugin.so", false},
+	}
+	for _, c := range cases {
+		if got := IsNoisyDlopenLib(c.path); got != c.want {
+			t.Errorf("IsNoisyDlopenLib(%q) = %v, want %v", c.path, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- The `isSystemLib` unification (c5c06a7) merged install-time `ldd` filtering and runtime dlopen-rediscovery filtering into one regex (the union of both lists). That silently changed install-time behavior: libselinux, libsystemd, libpam, libaudit, libdbus, libudev, libmount, libblkid, libuuid, and the glib/gobject/gio stack were previously only skipped for noisy *runtime* dlopen rediscovery, never for static `ldd`-based enumeration.
- After the merge, a binary directly linking any of them (an ordinary `ldd` dependency) got those functions silently dropped from install-time enumeration too — confirmed losing 1124 functions (`libselinux.so.1` + `libsystemd.so.0` entirely) on a real coverage run.
- Splits `funkutil.IsSystemLib` back into two: `IsSystemLib` (glibc/ld.so-family only, used by install-time `ParseLddLibraries`) and `IsNoisyDlopenLib` (`IsSystemLib`'s set plus the bulky/common dlopen targets, used by runtime `handleDynamicLoad`). Keeps the one genuine improvement from the original unification (libresolv/libnsl/libutil/libcrypt/libanl now consistently skipped everywhere) without the regression.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `./run_unit_tests.sh` passes, including new `TestIsNoisyDlopenLib` and extended `TestIsSystemLib` cases covering libselinux/libsystemd/libpam (the original "unified" test never covered these — how the regression shipped unnoticed)
- [x] Verified live against a real openQA coverage run: `libselinux.so.1`/`libsystemd.so.0` are back in the report, and total enumerated function count reconciles exactly against a known-good baseline (40507 − 132 legitimate ctor/dtor-dedup fix = 40375, matching precisely)