### PR TITLE
fix: resolve external debug info via .gnu_debuglink (fixes #128)

### DIFF
--- a/cmd/elfutil.go
+++ b/cmd/elfutil.go
@@ -57,21 +57,6 @@ func hasDebugInfo(path string) (bool, error) {
 		return true, nil
 	}
 
-	// Last resort: scan all .dwz files (handles fully-stripped packages like openssh)
-	binName := filepath.Base(path)
-	dwzDir := "/usr/lib/debug/.dwz"
-	if entries, err := os.ReadDir(dwzDir); err == nil {
-		for _, e := range entries {
-			if !e.IsDir() {
-				// Match by package name prefix, or by partial name matching for common patterns
-				name := e.Name()
-				if strings.HasPrefix(name, binName) || strings.Contains(name, binName) {
-					return true, nil
-				}
-			}
-		}
-	}
-
 	return false, nil
 }
 
@@ -81,9 +66,11 @@ func buildIDDebugPath(buildID string) string {
 
 // mergeDebugIfExternal merges external debug symbols into the binary using
 // eu-unstrip so DWARF traversal works even on stripped binaries.
-// Searches: .build-id paths, .gnu_debugaltlink (dwz), and .dwz/ directory.
-func mergeDebugIfExternal(binPath string) error {
-	debugPath, err := locateExternalDebugForMerge(binPath)
+// origPath is the binary's original absolute location (before any move to
+// SAFE_BIN_DIR), needed to resolve .gnu_debuglink's directory-relative
+// convention. Searches: .build-id paths, .gnu_debuglink, and .gnu_debugaltlink.
+func mergeDebugIfExternal(binPath, origPath string) error {
+	debugPath, err := locateExternalDebugForMerge(binPath, origPath)
 	if err != nil || debugPath == "" {
 		return err
 	}
@@ -93,7 +80,7 @@ func mergeDebugIfExternal(binPath string) error {
 // locateExternalDebugForMerge returns the external debug file path to merge
 // into binPath, or "" if the binary already has embedded debug info or no
 // external file is found.
-func locateExternalDebugForMerge(binPath string) (string, error) {
+func locateExternalDebugForMerge(binPath, origPath string) (string, error) {
 	f, err := elf.Open(binPath)
 	if err != nil {
 		return "", fmt.Errorf("open elf: %w", err)
@@ -113,21 +100,18 @@ func locateExternalDebugForMerge(binPath string) (string, error) {
 		}
 	}
 
+	if linkPath := debugLinkPath(origPath, readGnuDebugLink(f)); linkPath != "" {
+		if _, err := os.Stat(linkPath); err == nil {
+			return linkPath, nil
+		}
+	}
+
 	if altPath := readGnuDebugAltLink(f); altPath != "" {
 		if debugPath := findDebugFile(altPath); debugPath != "" {
 			return debugPath, nil
 		}
 	}
 
-	binName := filepath.Base(binPath)
-	dwzDir := "/usr/lib/debug/.dwz"
-	if entries, err := os.ReadDir(dwzDir); err == nil {
-		for _, e := range entries {
-			if !e.IsDir() && strings.HasPrefix(e.Name(), binName) {
-				return filepath.Join(dwzDir, e.Name()), nil
-			}
-		}
-	}
 	return "", nil
 }
 
@@ -146,6 +130,40 @@ func readGnuDebugAltLink(f *elf.File) string {
 		return string(data[:i])
 	}
 	return ""
+}
+
+// readGnuDebugLink extracts the debug file basename from the standard
+// .gnu_debuglink section (null-terminated name, then a padded CRC32 we
+// don't need here).
+func readGnuDebugLink(f *elf.File) string {
+	sec := f.Section(".gnu_debuglink")
+	if sec == nil {
+		return ""
+	}
+	data, err := sec.Data()
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	if i := bytes.IndexByte(data, 0); i > 0 {
+		return string(data[:i])
+	}
+	return ""
+}
+
+// debugLinkPath resolves the standard GNU debug-link convention used by
+// rpm/dpkg debuginfo packages: <debugRoot>/<canonical-dir-of-binary>/<name>.
+// The directory must be canonicalized (e.g. /lib64 -> /usr/lib64 on
+// merged-/usr systems) since that's where debuginfo packages actually
+// install their files.
+func debugLinkPath(origPath, linkName string) string {
+	if linkName == "" {
+		return ""
+	}
+	dir := filepath.Dir(origPath)
+	if real, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = real
+	}
+	return filepath.Join(globalDebugRoot, dir, linkName)
 }
 
 // findDebugFile locates a debug file given an alt-link path.

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -174,6 +174,15 @@ func dwarfFunctions(path string, filter *FuncFilter) ([]string, error) {
 		return nil, fmt.Errorf("open elf: %w", err)
 	}
 	defer f.Close()
+	if !hasEmbeddedDebugInfo(f) {
+		// No .debug_info anywhere in this file: there's nothing to parse.
+		// This is the common, expected case once every external-debug
+		// lookup has failed — not a real error, so let the caller treat it
+		// as "no functions found" instead of surfacing a raw stdlib parser
+		// error (Go's debug/dwarf errors on a missing/empty .debug_info
+		// with a cryptic "too short" rather than reporting its absence).
+		return nil, nil
+	}
 	dw, err := f.DWARF()
 	if err != nil {
 		return nil, fmt.Errorf("dwarf: %w", err)
@@ -181,9 +190,18 @@ func dwarfFunctions(path string, filter *FuncFilter) ([]string, error) {
 	return enumerateDWARF(dw, filter)
 }
 
+func hasEmbeddedDebugInfo(f *elf.File) bool {
+	for _, s := range f.Sections {
+		if s.Name == ".debug_info" && s.Size > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // externalDebugPath returns the path to an external .debug file, or "".
-// Tries: .build-id layout, then .gnu_debugaltlink (dwz-compressed), then
-// brute-force search in /usr/lib/debug/.dwz/ by package name.
+// Tries: .build-id layout, then .gnu_debuglink (standard GNU separate-debug
+// convention), then .gnu_debugaltlink (dwz-compressed).
 func externalDebugPath(binPath string) string {
 	f, err := elf.Open(binPath)
 	if err != nil {
@@ -197,6 +215,13 @@ func externalDebugPath(binPath string) string {
 		p := buildIDDebugPath(buildID)
 		if _, err := os.Stat(p); err == nil {
 			return p
+		}
+	}
+
+	// Try .gnu_debuglink: <debugRoot>/<canonical-dir-of-binary>/<name>
+	if linkPath := debugLinkPath(binPath, readGnuDebugLink(f)); linkPath != "" {
+		if _, err := os.Stat(linkPath); err == nil {
+			return linkPath
 		}
 	}
 
@@ -216,18 +241,6 @@ func externalDebugPath(binPath string) string {
 			dwzPath := filepath.Join("/usr/lib/debug/.dwz", base)
 			if _, err := os.Stat(dwzPath); err == nil {
 				return dwzPath
-			}
-		}
-	}
-
-	// Brute-force: scan .dwz dir for package matching binary name
-	binName := filepath.Base(binPath)
-	dwzDir := "/usr/lib/debug/.dwz"
-	entries, err := os.ReadDir(dwzDir)
-	if err == nil {
-		for _, e := range entries {
-			if !e.IsDir() && (strings.HasPrefix(e.Name(), binName) || strings.Contains(e.Name(), binName)) {
-				return filepath.Join(dwzDir, e.Name())
 			}
 		}
 	}

--- a/cmd/funkoverage_test.go
+++ b/cmd/funkoverage_test.go
@@ -120,7 +120,7 @@ func TestLocateExternalDebugForMerge(t *testing.T) {
 	}
 
 	// No external debug file placed yet: nothing to find.
-	if got, err := locateExternalDebugForMerge(bin); err != nil || got != "" {
+	if got, err := locateExternalDebugForMerge(bin, bin); err != nil || got != "" {
 		t.Errorf("locateExternalDebugForMerge before placing debug file = (%q, %v), want (\"\", nil)", got, err)
 	}
 
@@ -132,12 +132,112 @@ func TestLocateExternalDebugForMerge(t *testing.T) {
 	if err := os.WriteFile(debugFile, []byte("dummy debug info"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := locateExternalDebugForMerge(bin)
+	got, err := locateExternalDebugForMerge(bin, bin)
 	if err != nil {
 		t.Fatalf("locateExternalDebugForMerge: %v", err)
 	}
 	if got != debugFile {
 		t.Errorf("locateExternalDebugForMerge = %q, want %q", got, debugFile)
+	}
+}
+
+// TestLocateExternalDebugForMerge_DebugLink verifies the .gnu_debuglink
+// fallback: when build-id resolution fails (e.g. a missing/stale
+// .build-id symlink), the debug file is still found via the standard
+// <debugRoot>/<canonical-dir-of-binary>/<debuglink-basename> convention
+// used by rpm/dpkg debuginfo packages.
+func TestLocateExternalDebugForMerge_DebugLink(t *testing.T) {
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not found")
+	}
+	if _, err := exec.LookPath("objcopy"); err != nil {
+		t.Skip("objcopy not found")
+	}
+	tmp := t.TempDir()
+	orig := globalDebugRoot
+	globalDebugRoot = filepath.Join(tmp, "debugroot")
+	defer func() { globalDebugRoot = orig }()
+
+	binDir := filepath.Join(tmp, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(tmp, "main.c")
+	if err := os.WriteFile(src, []byte("int main() { return 0; }"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(binDir, "prog")
+	if out, err := exec.Command("gcc", "-g", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, out)
+	}
+	realBinDir, err := filepath.EvalSymlinks(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	debugDir := filepath.Join(globalDebugRoot, realBinDir)
+	if err := os.MkdirAll(debugDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	debugFile := filepath.Join(debugDir, "prog.debug")
+	if out, err := exec.Command("objcopy", "--only-keep-debug", bin, debugFile).CombinedOutput(); err != nil {
+		t.Fatalf("objcopy --only-keep-debug: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("objcopy", "--strip-debug", "--add-gnu-debuglink="+debugFile, bin).CombinedOutput(); err != nil {
+		t.Fatalf("objcopy --add-gnu-debuglink: %v\n%s", err, out)
+	}
+
+	got, err := locateExternalDebugForMerge(bin, bin)
+	if err != nil {
+		t.Fatalf("locateExternalDebugForMerge: %v", err)
+	}
+	if got != debugFile {
+		t.Errorf("locateExternalDebugForMerge via .gnu_debuglink = %q, want %q", got, debugFile)
+	}
+}
+
+// TestExternalDebugPath_IgnoresDwzFile verifies that a same-named file
+// sitting in a .dwz/-style directory is never picked up as a substitute
+// debug source: it can never provide a symtab or a standalone-parseable
+// .debug_info (see issue #128), so treating it as found is worse than
+// reporting no debug info at all.
+func TestExternalDebugPath_IgnoresDwzFile(t *testing.T) {
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not found")
+	}
+	if _, err := exec.LookPath("strip"); err != nil {
+		t.Skip("strip not found")
+	}
+	tmp := t.TempDir()
+	orig := globalDebugRoot
+	globalDebugRoot = tmp
+	defer func() { globalDebugRoot = orig }()
+
+	src := filepath.Join(tmp, "main.c")
+	if err := os.WriteFile(src, []byte("int main() { return 0; }"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(tmp, "cpupower")
+	if out, err := exec.Command("gcc", "-g", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("strip", "--strip-all", bin).CombinedOutput(); err != nil {
+		t.Fatalf("strip: %v\n%s", err, out)
+	}
+
+	dwzDir := filepath.Join(tmp, ".dwz")
+	if err := os.MkdirAll(dwzDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dwzDir, "cpupower-1.0-1.x86_64"), []byte("not a real debug file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := externalDebugPath(bin); got != "" {
+		t.Errorf("externalDebugPath picked up a .dwz/ file as a debug source: %q, want \"\"", got)
+	}
+	if got, err := locateExternalDebugForMerge(bin, bin); err != nil || got != "" {
+		t.Errorf("locateExternalDebugForMerge picked up a .dwz/ file as a debug source: (%q, %v), want (\"\", nil)", got, err)
 	}
 }
 

--- a/cmd/shim.go
+++ b/cmd/shim.go
@@ -70,7 +70,8 @@ func install(targetBinary string, noLibs bool, filter *FuncFilter) error {
 	if err := move(realTarget, safePath); err != nil {
 		return err
 	}
-	if err := mergeDebugIfExternal(safePath); err != nil {
+	if err := mergeDebugIfExternal(safePath, realTarget); err != nil {
+		_ = move(safePath, realTarget)
 		return fmt.Errorf("merge debug symbols: %w", err)
 	}
 

--- a/tests/e2e/test_cpupower.sh
+++ b/tests/e2e/test_cpupower.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# E2E test: funkoverage coverage of cpupower (regression guard for issue #128).
+#
+# cpupower's debuginfo package resolves via .gnu_debuglink, not always via
+# .build-id (a stale/missing .build-id symlink is a realistic real-world
+# packaging skew). funkoverage used to have no .gnu_debuglink support at
+# all, so whenever .build-id resolution failed it fell through to parsing
+# the stripped binary's own (absent) DWARF, crashing with:
+#   dwarf: decoding dwarf section info at offset 0x0: too short
+#
+# This test deliberately breaks the .build-id symlink before installing, so
+# a regression in .gnu_debuglink resolution is actually exercised rather
+# than silently masked by the (already-working) .build-id path.
+# Run as root on openSUSE with funkoverage in PATH.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib_test_helpers.sh"
+
+BINARY=""
+BID_FILE=""
+BID_BACKUP=""
+
+cleanup() {
+    [[ -n "$BINARY" ]] && funkoverage uninstall "$BINARY" 2>/dev/null || true
+    if [[ -n "$BID_BACKUP" && -f "$BID_BACKUP" ]]; then
+        mv "$BID_BACKUP" "$BID_FILE"
+    fi
+}
+trap cleanup EXIT
+
+# --- Prerequisites ---
+header "Prerequisites"
+require_root
+require_funkoverage
+ensure_packages cpupower cpupower-debuginfo
+
+BINARY=$(which cpupower)
+require_debug_symbols "$BINARY"
+pass "cpupower with debug symbols"
+
+# --- Break .build-id resolution to force the .gnu_debuglink fallback ---
+header "Simulating stale/missing .build-id symlink"
+BUILD_ID=$(readelf -n "$BINARY" 2>/dev/null | grep -A1 "Build ID" | grep "Build ID" | awk '{print $3}')
+[[ -n "$BUILD_ID" ]] || fail "could not read cpupower's build-id"
+BID_FILE="/usr/lib/debug/.build-id/${BUILD_ID:0:2}/${BUILD_ID:2}.debug"
+if [[ -e "$BID_FILE" ]]; then
+    BID_BACKUP="${BID_FILE}.funkoverage-bak"
+    mv "$BID_FILE" "$BID_BACKUP"
+    pass "build-id symlink moved aside: $BID_FILE"
+else
+    info "build-id symlink already absent — condition already present"
+fi
+
+# --- Setup ---
+header "Setup"
+clean_coverage_data
+install_shim "$BINARY"
+pass "Shim installed via .gnu_debuglink resolution (not .build-id)"
+
+FLOG=$(ls -t /var/coverage/data/*"$(basename "$BINARY")"*_functions.log | head -1)
+FUNC_COUNT=$(grep -c "^FUNC " "$FLOG")
+[[ "$FUNC_COUNT" -gt 100 ]] || fail "expected >100 functions enumerated, got $FUNC_COUNT"
+pass "$FUNC_COUNT functions enumerated with .build-id broken"
+
+# --- Exercise ---
+header "Exercising cpupower"
+"$BINARY" frequency-info || true
+"$BINARY" -h || true
+pass "frequency-info + help"
+
+# --- Report ---
+header "Coverage report"
+REPORT_DIR=$(generate_report)
+assert_min_called "*cpupower*" 5
+remove_report_dir "$REPORT_DIR"
+
+# --- Uninstall ---
+header "Uninstall"
+uninstall_and_verify "$BINARY"
+BINARY="" # prevent double-uninstall in trap
+
+# Restore build-id symlink
+if [[ -n "$BID_BACKUP" && -f "$BID_BACKUP" ]]; then
+    mv "$BID_BACKUP" "$BID_FILE"
+    BID_BACKUP="" # prevent double-restore in trap
+    pass "build-id symlink restored"
+fi
+
+echo ""
+echo -e "${GREEN}ALL TESTS PASSED${NC} (cpupower, .gnu_debuglink resolution)"


### PR DESCRIPTION
funkoverage install crashed on cpupower with "dwarf: decoding dwarf section info at offset 0x0: too short" whenever .build-id resolution failed (stale/missing symlink), because the fallback chain never implemented .gnu_debuglink — the standard GNU mechanism every distro debuginfo package actually uses. It fell through to parsing the stripped binary's own absent DWARF instead, which Go's stdlib reports with this cryptic "too short" error rather than "no debug info". Also removes the unsound brute-force scan of /usr/lib/debug/.dwz/, which could only ever select DWZ's shared multi-binary common-info object (no program headers, no symtab, stub .debug_info) — never a real per-binary debug file — and fixes a rollback gap where a failed debug merge left the target binary stranded outside SAFE_BIN_DIR.

Reproduced and verified against the real cpupower/cpupower-debuginfo packages on a VM matching the issue's environment.