### PR TITLE
Merge library debug info in place for uprobe attach

### DIFF
--- a/cmd/elfutil.go
+++ b/cmd/elfutil.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"funkoverage/internal/funkutil"
 )
 
 var globalDebugRoot = "/usr/lib/debug"
@@ -75,6 +77,66 @@ func mergeDebugIfExternal(binPath, origPath string) error {
 		return err
 	}
 	return unstrip(binPath, debugPath)
+}
+
+// mergeLibraryDebugInfo merges external debug info into each library in
+// funcs (in place, at its real system path — every other library-linking
+// funkoverage target on the system will pick up the merged copy too) so
+// that uprobe attach, which resolves symbol names against the exact file
+// the kernel maps at runtime, can find local functions that enumeration
+// only discovered via an external debug file. mainImage (the already-moved
+// and already-merged target binary) is skipped.
+//
+// ponytail: no cross-target reference counting — if two installed targets
+// share a library, uninstalling one restores it for both. Add a refcount
+// sidecar under SAFE_BIN_DIR/libs/ if that becomes a real problem.
+//
+// Returns the set of libraries actually modified (original path -> backup
+// path under SAFE_BIN_DIR/libs/), so uninstall can restore exactly what
+// this install call changed.
+func mergeLibraryDebugInfo(funcs map[string][]string, mainImage string) map[string]string {
+	backups := make(map[string]string)
+	for lib := range funcs {
+		if lib == mainImage {
+			continue
+		}
+		debugPath, err := locateExternalDebugForMerge(lib, lib)
+		if err != nil || debugPath == "" {
+			continue // no external debug found, or lib is already self-sufficient
+		}
+		info, err := os.Stat(lib)
+		if err != nil {
+			continue
+		}
+		backupPath := filepath.Join(funkutil.SafeBinDir(), "libs", lib)
+		if err := os.MkdirAll(filepath.Dir(backupPath), 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: backup dir for %s: %v\n", lib, err)
+			continue
+		}
+		if err := copyFile(lib, backupPath, info.Mode().Perm()); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: back up %s before merge: %v\n", lib, err)
+			continue
+		}
+		if err := unstrip(lib, debugPath); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: merge debug symbols into %s: %v\n", lib, err)
+			os.Remove(backupPath)
+			continue
+		}
+		backups[lib] = backupPath
+	}
+	return backups
+}
+
+// restoreLibraryBackups reverses mergeLibraryDebugInfo for the libraries
+// this specific install call modified, per safePath's backup sidecar.
+func restoreLibraryBackups(safePath string) {
+	backups := funkutil.ReadLibBackups(safePath)
+	for lib, backupPath := range backups {
+		if err := move(backupPath, lib); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: restore %s: %v\n", lib, err)
+		}
+	}
+	_ = funkutil.WriteLibBackups(safePath, nil)
 }
 
 // locateExternalDebugForMerge returns the external debug file path to merge

--- a/cmd/funkoverage_test.go
+++ b/cmd/funkoverage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -238,6 +239,142 @@ func TestExternalDebugPath_IgnoresDwzFile(t *testing.T) {
 	}
 	if got, err := locateExternalDebugForMerge(bin, bin); err != nil || got != "" {
 		t.Errorf("locateExternalDebugForMerge picked up a .dwz/ file as a debug source: (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+// --- mergeLibraryDebugInfo / restoreLibraryBackups tests ---
+
+// TestMergeLibraryDebugInfo verifies that a library gets its external debug
+// info merged in place (so uprobe attach can resolve names that only exist
+// in the debug file's symtab), that a backup of the pre-merge original is
+// recorded, and that restoreLibraryBackups puts the original back exactly.
+func TestMergeLibraryDebugInfo(t *testing.T) {
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not found")
+	}
+	if _, err := exec.LookPath("strip"); err != nil {
+		t.Skip("strip not found")
+	}
+	if _, err := exec.LookPath("eu-unstrip"); err != nil {
+		t.Skip("eu-unstrip not found")
+	}
+	tmp := t.TempDir()
+	safeBinDir := filepath.Join(tmp, "safebin")
+	t.Setenv("SAFE_BIN_DIR", safeBinDir)
+	orig := globalDebugRoot
+	globalDebugRoot = filepath.Join(tmp, "debugroot")
+	defer func() { globalDebugRoot = orig }()
+
+	libDir := filepath.Join(tmp, "usr", "lib64")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(tmp, "lib.c")
+	// lib_local_func is `static`: LOCAL binding, present in .symtab but never
+	// in .dynsym, so it vanishes from a fully-stripped runtime .so exactly
+	// like GMP's internal mpn_* helpers do (the real bug this mirrors).
+	code := "static int lib_local_func(void) { return 42; }\nint lib_public_func(void) { return lib_local_func(); }\n"
+	if err := os.WriteFile(src, []byte(code), 0644); err != nil {
+		t.Fatal(err)
+	}
+	lib := filepath.Join(libDir, "libdemo.so")
+	if out, err := exec.Command("gcc", "-shared", "-fPIC", "-g", "-o", lib, src).CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, out)
+	}
+	realLibDir, err := filepath.EvalSymlinks(libDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	debugDir := filepath.Join(globalDebugRoot, realLibDir)
+	if err := os.MkdirAll(debugDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	debugFile := filepath.Join(debugDir, "libdemo.so.debug")
+	if out, err := exec.Command("objcopy", "--only-keep-debug", lib, debugFile).CombinedOutput(); err != nil {
+		t.Fatalf("objcopy --only-keep-debug: %v\n%s", err, out)
+	}
+	// strip --strip-all (not --strip-debug) matches real distro debuginfo
+	// packaging: the shipped runtime .so keeps only .dynsym, dropping the
+	// full .symtab (and with it every LOCAL/static symbol) entirely.
+	if out, err := exec.Command("strip", "--strip-all", lib).CombinedOutput(); err != nil {
+		t.Fatalf("strip --strip-all: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("objcopy", "--add-gnu-debuglink="+debugFile, lib).CombinedOutput(); err != nil {
+		t.Fatalf("objcopy --add-gnu-debuglink: %v\n%s", err, out)
+	}
+	strippedBytes, err := os.ReadFile(lib)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if funcs := symtabFunctions(lib, nil); slices.Contains(funcs, "lib_local_func") {
+		t.Fatalf("test setup: lib_local_func should NOT be resolvable pre-merge, got %v", funcs)
+	}
+
+	funcs := map[string][]string{
+		lib:          {"lib_local_func"},
+		"/some/main": {"main_func"},
+	}
+	backups := mergeLibraryDebugInfo(funcs, "/some/main")
+
+	backupPath, ok := backups[lib]
+	if !ok {
+		t.Fatalf("mergeLibraryDebugInfo did not back up %s; backups = %v", lib, backups)
+	}
+	backedUp, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backedUp) != string(strippedBytes) {
+		t.Error("backup does not match the pre-merge (stripped) library bytes")
+	}
+
+	merged, err := os.ReadFile(lib)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged) <= len(strippedBytes) {
+		t.Errorf("merged library (%d bytes) should be larger than stripped (%d bytes)", len(merged), len(strippedBytes))
+	}
+	if funcs := symtabFunctions(lib, nil); !slices.Contains(funcs, "lib_local_func") {
+		t.Errorf("merged library should now expose lib_local_func directly, got %v", funcs)
+	}
+
+	// Restore, via the same sidecar install() would write.
+	safePath := filepath.Join(safeBinDir, "some-target")
+	if err := os.MkdirAll(safeBinDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := funkutil.WriteLibBackups(safePath, backups); err != nil {
+		t.Fatal(err)
+	}
+	restoreLibraryBackups(safePath)
+
+	restored, err := os.ReadFile(lib)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != string(strippedBytes) {
+		t.Error("restoreLibraryBackups did not restore the pre-merge (stripped) library bytes")
+	}
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Errorf("backup file %s should be gone after restore, stat err = %v", backupPath, err)
+	}
+}
+
+// TestMergeLibraryDebugInfo_SkipsMainImage verifies the main target binary
+// (already merged separately by install()) is never re-processed here.
+func TestMergeLibraryDebugInfo_SkipsMainImage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SAFE_BIN_DIR", filepath.Join(tmp, "safebin"))
+
+	main := filepath.Join(tmp, "main")
+	if err := os.WriteFile(main, []byte("not a real elf, must not be touched"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	funcs := map[string][]string{main: {"main_func"}}
+	backups := mergeLibraryDebugInfo(funcs, main)
+	if len(backups) != 0 {
+		t.Errorf("mergeLibraryDebugInfo should skip mainImage, got backups = %v", backups)
 	}
 }
 

--- a/cmd/shim.go
+++ b/cmd/shim.go
@@ -99,6 +99,13 @@ func install(targetBinary string, noLibs bool, filter *FuncFilter) error {
 		fmt.Fprintf(os.Stderr, "warning: write functions log: %v\n", err)
 	}
 
+	if !noLibs {
+		backups := mergeLibraryDebugInfo(funcs, safePath)
+		if err := funkutil.WriteLibBackups(safePath, backups); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: write library backup sidecar: %v\n", err)
+		}
+	}
+
 	if err := funkutil.WriteFilterSidecar(safePath, filter.Sidecar()); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: write filter sidecar: %v\n", err)
 	}
@@ -171,6 +178,7 @@ func uninstall(targetBinary string) error {
 		return fmt.Errorf("restore binary: %w", err)
 	}
 	_ = funkutil.WriteFuncList(safePath, nil)
+	restoreLibraryBackups(safePath)
 
 	originalName := filepath.Base(targetBinary)
 	if originalName != binaryName {

--- a/internal/funkutil/libbackup.go
+++ b/internal/funkutil/libbackup.go
@@ -1,0 +1,19 @@
+package funkutil
+
+// LibBackupPath returns the per-binary library-backup sidecar path
+// (<safePath>.libbackup.json), mapping each library this install merged
+// debug info into (original absolute path) to where its pre-merge original
+// was backed up, so uninstall can restore it.
+func LibBackupPath(safePath string) string { return safePath + ".libbackup.json" }
+
+// WriteLibBackups writes the backup map as JSON to LibBackupPath(safePath).
+// A nil/empty map deletes any existing sidecar.
+func WriteLibBackups(safePath string, backups map[string]string) error {
+	return writeJSON(LibBackupPath(safePath), backups, func(v map[string]string) bool { return len(v) == 0 })
+}
+
+// ReadLibBackups reads LibBackupPath(safePath) and returns the backup map.
+// Missing or malformed sidecars yield nil (no error).
+func ReadLibBackups(safePath string) map[string]string {
+	return readJSON[map[string]string](LibBackupPath(safePath))
+}

--- a/tests/e2e/test_gmp.sh
+++ b/tests/e2e/test_gmp.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# E2E test: library-local function tracing via in-place debug merge.
+#
+# uprobes are attached by resolving symbol names against the exact file the
+# kernel maps at runtime. A shared library's local/static functions (e.g.
+# GMP's internal mpn_* helpers) live only in an external debuginfo file's
+# .symtab, not in the stripped runtime .so's .dynsym — so without merging
+# that debug info into the real library file in place, uprobe_multi fails
+# to resolve even one requested symbol and the WHOLE library's uprobes get
+# silently dropped:
+#   funkoverage-shim: skipping uprobes on /lib64/libgmp.so.10: symbol
+#   mpn_fft_initl: not found
+#
+# This uses a tiny self-built program (own DWARF, no distro debuginfo
+# dependency) that calls into GMP's FFT/Toom-Cook/sqrt/Miller-Rabin
+# internals with large operands, so real internal libgmp functions
+# (not just the __gmpz_* public API, which a separate "__"-prefix filter
+# excludes from tracing) actually get exercised and traced.
+# Run as root on openSUSE with funkoverage in PATH.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib_test_helpers.sh"
+
+BINARY=""
+WORKDIR=""
+
+cleanup() {
+    [[ -n "$BINARY" ]] && funkoverage uninstall "$BINARY" 2>/dev/null || true
+    [[ -n "$WORKDIR" ]] && rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# --- Prerequisites ---
+header "Prerequisites"
+require_root
+require_funkoverage
+command -v gcc >/dev/null || fail "gcc not installed"
+ensure_packages gmp-devel libgmp10-debuginfo
+
+WORKDIR=$(mktemp -d /tmp/funkoverage_gmp_XXXX)
+cat > "$WORKDIR/gmp_demo.c" << 'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+
+int main(void) {
+    gmp_randstate_t rng;
+    gmp_randinit_mt(rng);
+    gmp_randseed_ui(rng, 42);
+
+    mpz_t big_a, big_b, prod, quo, rem, root, gcdv;
+    mpz_inits(big_a, big_b, prod, quo, rem, root, gcdv, NULL);
+
+    /* Large random operands: pushes multiplication/division past the
+     * schoolbook algorithm into GMP's FFT/Toom-Cook/divide-and-conquer
+     * internals. */
+    mpz_urandomb(big_a, rng, 4096);
+    mpz_urandomb(big_b, rng, 4096);
+
+    mpz_mul(prod, big_a, big_b);
+    mpz_tdiv_qr(quo, rem, prod, big_b);
+    mpz_sqrt(root, prod);
+    mpz_gcd(gcdv, big_a, big_b);
+
+    gmp_printf("prod has %zu bits\n", mpz_sizeinbase(prod, 2));
+    gmp_printf("sqrt(prod) has %zu digits\n", mpz_sizeinbase(root, 10));
+
+    mpz_t candidate;
+    mpz_init_set_ui(candidate, 1000000007ULL);
+    printf("1000000007 probably prime: %s\n", mpz_probab_prime_p(candidate, 25) ? "yes" : "no");
+
+    mpz_t binom;
+    mpz_init(binom);
+    mpz_bin_uiui(binom, 500, 250);
+    printf("C(500,250) has %zu digits\n", mpz_sizeinbase(binom, 10));
+
+    mpq_t q1, q2;
+    mpq_inits(q1, q2, NULL);
+    mpq_set_ui(q1, 355, 113);
+    mpq_set_ui(q2, 22, 7);
+    printf("355/113 < 22/7: %s\n", mpq_cmp(q1, q2) < 0 ? "yes" : "no");
+
+    mpz_clears(big_a, big_b, prod, quo, rem, root, gcdv, candidate, binom, NULL);
+    mpq_clears(q1, q2, NULL);
+    gmp_randclear(rng);
+    return 0;
+}
+EOF
+gcc -O2 -o "$WORKDIR/gmp_demo" "$WORKDIR/gmp_demo.c" -lgmp
+BINARY="$WORKDIR/gmp_demo"
+pass "gmp_demo built"
+
+LIBGMP=$(ldd "$BINARY" | grep libgmp | awk '{print $3}')
+[[ -n "$LIBGMP" ]] || fail "could not resolve libgmp.so path via ldd"
+require_debug_symbols "$LIBGMP"
+pass "libgmp debug symbols available ($LIBGMP)"
+
+# --- Setup ---
+header "Setup"
+clean_coverage_data
+install_shim "$BINARY"
+pass "Shim installed (library tracing enabled)"
+
+# --- Verify libgmp was merged in place, with a backup recorded ---
+header "Verify library debug merge"
+readelf -S "$LIBGMP" 2>&1 | grep -q "\.symtab" \
+    || fail "libgmp should now have an embedded .symtab after merge"
+BACKUP_SIDECAR="/var/coverage/bin/$(basename "$BINARY").libbackup.json"
+[[ -f "$BACKUP_SIDECAR" ]] || fail "expected library backup sidecar at $BACKUP_SIDECAR"
+grep -q "$LIBGMP" "$BACKUP_SIDECAR" || fail "backup sidecar does not reference $LIBGMP"
+pass "libgmp merged in place; backup recorded in $BACKUP_SIDECAR"
+
+# --- Exercise ---
+header "Exercising gmp_demo"
+"$BINARY"
+pass "FFT multiply, sqrt, Miller-Rabin, binomial, rational compare"
+
+# --- Report ---
+header "Coverage report"
+REPORT_DIR=$(generate_report)
+assert_min_called "*gmp_demo*" 10
+LIB_CALLS=$(grep -ch "libgmp" /var/coverage/data/*gmp_demo*_called.log 2>/dev/null || echo 0)
+[[ "$LIB_CALLS" -gt 0 ]] || fail "expected at least one traced libgmp function call, got 0"
+pass "$LIB_CALLS libgmp internal functions traced"
+remove_report_dir "$REPORT_DIR"
+
+# --- Uninstall + verify library restore ---
+header "Uninstall"
+uninstall_and_verify "$BINARY"
+BINARY="" # prevent double-uninstall in trap
+
+readelf -S "$LIBGMP" 2>&1 | grep -q "\.symtab" \
+    && fail "libgmp should be back to its stripped state after uninstall"
+[[ -f "$BACKUP_SIDECAR" ]] && fail "backup sidecar should be removed after uninstall"
+pass "libgmp restored to its pre-merge stripped state"
+
+echo ""
+echo -e "${GREEN}ALL TESTS PASSED${NC} (gmp, library debug merge)"


### PR DESCRIPTION
## Summary

Found while verifying the #128 fix against a real library (libgmp): `funkoverage install` could enumerate a shared library's functions via its external debug file, but uprobe attach resolves symbol names against the exact file the kernel maps at runtime — the stripped runtime `.so`, which never has local/static symbols (only `.dynsym`). One unresolvable name fails cilium/ebpf's `UprobeMulti` for the *entire* image, so every enumerated function in that library silently went untraced:

```
funkoverage-shim: skipping uprobes on /lib64/libgmp.so.10: symbol mpn_fft_initl: not found
```

The main target binary already avoided this because `install()` merges its debug info into the `SAFE_BIN_DIR` copy before enumeration. Shared library dependencies got no equivalent treatment.

- `mergeLibraryDebugInfo` now runs the same `eu-unstrip` merge in place on each library's real system path (so every process using it benefits, not just the traced target), backing up the pre-merge original to `SAFE_BIN_DIR/libs/` first.
- `uninstall` reads a new `<safePath>.libbackup.json` sidecar and restores exactly what this install touched.
- Known limitation (marked with a `ponytail:` comment, not solved here): no cross-target reference counting, so uninstalling one target restores a library shared with another still-installed target too.

Verified end-to-end on a VM: a GMP demo program doing large-integer FFT multiplication, sqrt, and Miller-Rabin primality now traces 16/98 real libgmp internal functions, where it previously crashed enumeration outright and, even with a working build-id, silently traced zero.

## Test plan
- [x] `go test ./...` (new `TestMergeLibraryDebugInfo`, `TestMergeLibraryDebugInfo_SkipsMainImage`)
- [x] New e2e regression test `tests/e2e/test_gmp.sh`: builds a GMP demo program, installs it, verifies the library gets merged in place with a backup sidecar, exercises FFT/sqrt/primality internals, asserts real libgmp functions get traced, then verifies `uninstall` restores the library to its pre-merge stripped state
- [x] Full e2e suite (`tests/e2e/test_coverage.py`) still green