### PR TITLE
test(e2e): add openSUSE Leap 16.0 and Tumbleweed containerized E2E test suites

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,87 @@
+# BinaryCoverage (funkoverage) Test Suite
+
+This directory contains the automated and manual testing tools for the `funkoverage` code coverage framework.
+
+The test suite is structured into two main tiers:
+1. **Unit Tests**: Safe, non-privileged tests covering compiler and parser utilities.
+2. **End-to-End (E2E) Tests**: Privileged tests running on real system binaries to verify the eBPF uprobe engine, daemon tracking, dynamic library attachment, and report generation.
+
+---
+
+## 1. Unit Tests
+
+- **Location**: Executed via the `./run_unit_tests.sh` script at the root directory.
+- **Privileges**: No root or BPF privileges required.
+- **What they cover**:
+  - `internal/funkutil/`: Log parsing, regex-free scanners, sidecar JSON reading/writing, and `.symtab` / `.dynsym` symbol parsing.
+  - `cmd/`: Configuration parsing, templates, and basic UI generation.
+- **How to run**:
+  ```bash
+  ./run_unit_tests.sh
+  ```
+
+---
+
+## 2. End-to-End (E2E) Sample Testing
+
+Verify basic binary tracing quickly using a custom target application:
+- **Location**: `tests/sample/`
+- **Privileges**: Requires `sudo` (for BPF uprobes loading).
+- **How to run**:
+  ```bash
+  # Build the sample binary
+  cd tests/sample && make && cd ../..
+
+  # Trace execution
+  sudo ./funkoverage trace tests/sample/sample -- --strings
+
+  # Generate text/HTML reports
+  sudo ./funkoverage report /var/coverage/data /tmp/report_sample --formats txt,html
+  ```
+
+---
+
+## 3. Distro System Binary E2E Tests
+
+These tests instrument real system utilities on the host to verify deep features like dynamic loading (`dlopen`), C++ demangling, `.gnu_debuglink` fallback, and in-place debug info merges.
+
+- **Location**: `tests/e2e/`
+- **Privileges**: Must run as `root` (with `/sys/kernel/btf/vmlinux` available).
+- **Required Host OS**: openSUSE / SUSE (scripts dynamically invoke `zypper` to fetch debug symbols).
+
+### Distro Test Directory:
+
+| Script | Binary | Key Feature Verified | Required Packages |
+|---|---|---|---|
+| `test_bzip2.sh` | `/usr/bin/bzip2` | Basic lifecycle: install, trace, report, uninstall | `bzip2`, `bzip2-debuginfo` |
+| `test_gzip.sh` | `/usr/bin/gzip` | Script wrappers (`gunzip`, `zcat`), multi-file and recursive runs | `gzip`, `gzip-debuginfo` |
+| `test_gmp.sh` | Custom C app | In-place debugmerge to trace library-local static symbols (e.g., `mpn_*` internal helpers) | `gmp-devel`, `libgmp10-debuginfo` |
+| `test_cpupower.sh` | `/usr/bin/cpupower` | `.gnu_debuglink` resolution when `.build-id` symlinks are broken/missing | `cpupower`, `cpupower-debuginfo` |
+| `test_openssl.sh` | `/usr/bin/openssl` | Multi-library tracing (`libssl.so`, `libcrypto.so`) | `openssl`, debug packages |
+| `test_squid.sh` | `/usr/sbin/squid` | C++ demangling, long-running daemon attachment, fork-tracking | `squid`, `squid-debuginfo`, `curl` |
+| `test_nginx_dlopen.sh` | `/usr/sbin/nginx` | `dlopen()` JIT uprobe attachment on dynamically loaded web modules | `nginx`, debug packages |
+| `test_pam_dlopen.sh` | `/usr/sbin/pam` | PAM modules loaded via `dlopen()` tracing | `pam`, `pam-debuginfo` |
+
+- **How to run a specific test**:
+  ```bash
+  sudo -E bash tests/e2e/test_bzip2.sh
+  ```
+
+---
+
+## 4. Containerized E2E Testing (Leap 16.0)
+
+To run all major system binary E2E tests in a clean, reproducible, and isolated environment, use the openSUSE Leap 16.0 containerized test runner.
+
+- **Location**: `tests/e2e/test_container_leap16.sh` and `tests/e2e/Containerfile`.
+- **Privileges**: Requires `sudo` (needs `--privileged` container runtime capabilities and `/sys/` resource sharing).
+- **Prerequisites**: `podman` (preferred) or `docker` installed.
+- **What it does**:
+  1. Builds a custom Leap 16.0 container image (`leap16-e2e`) containing Go, GCC, make, elfutils, and all debuginfo packages listed above.
+  2. Builds are cached, making repeat local execution extremely fast.
+  3. Launches the container in the host's PID namespace and mounts `/sys/kernel/btf`, `/sys/kernel/tracing`, and `/sys/kernel/debug`.
+  4. Automatically compiles and executes `test_bzip2.sh`, `test_gzip.sh`, `test_gmp.sh`, `test_cpupower.sh`, `test_openssl.sh`, and `test_squid.sh`.
+- **How to run**:
+  ```bash
+  ./tests/e2e/test_container_leap16.sh
+  ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,19 +69,24 @@ These tests instrument real system utilities on the host to verify deep features
 
 ---
 
-## 4. Containerized E2E Testing (Leap 16.0)
+## 4. Containerized E2E Testing (Leap 16.0 & Tumbleweed)
 
-To run all major system binary E2E tests in a clean, reproducible, and isolated environment, use the openSUSE Leap 16.0 containerized test runner.
+To run all major system binary E2E tests in a clean, reproducible, and isolated environment, use the openSUSE Leap 16.0 or Tumbleweed containerized test runners.
 
-- **Location**: `tests/e2e/test_container_leap16.sh` and `tests/e2e/Containerfile`.
+- **Location**: `tests/e2e/test_container_leap16.sh`, `tests/e2e/test_container_tumbleweed.sh`, `tests/e2e/run_all_container_tests.sh`, and `tests/e2e/Containerfile`.
 - **Privileges**: Requires `sudo` (needs `--privileged` container runtime capabilities and `/sys/` resource sharing).
 - **Prerequisites**: `podman` (preferred) or `docker` installed.
-- **What it does**:
-  1. Builds a custom Leap 16.0 container image (`leap16-e2e`) containing Go, GCC, make, elfutils, and all debuginfo packages listed above.
-  2. Builds are cached, making repeat local execution extremely fast.
-  3. Launches the container in the host's PID namespace and mounts `/sys/kernel/btf`, `/sys/kernel/tracing`, and `/sys/kernel/debug`.
-  4. Automatically compiles and executes `test_bzip2.sh`, `test_gzip.sh`, `test_gmp.sh`, `test_cpupower.sh`, `test_openssl.sh`, and `test_squid.sh`.
-- **How to run**:
+- **What they do**:
+  1. Build a custom container image (`leap16-e2e` or `tumbleweed-e2e`) from the shared `Containerfile` via build-args.
+  2. The image contains Go, GCC, make, elfutils, gawk, and all debuginfo packages for tested binaries.
+  3. Image builds are cached, making repeat local execution extremely fast.
+  4. Launches the container in the host's PID namespace and mounts `/sys/kernel/btf`, `/sys/kernel/tracing`, and `/sys/kernel/debug`.
+  5. Automatically executes a shared runner (`run_all_container_tests.sh`) to build `funkoverage` and run tests for: `bzip2`, `gzip`, `gmp`, `cpupower`, `openssl`, `squid`, and `nginx_dlopen`.
+- **How to run openSUSE Leap 16.0 container tests**:
   ```bash
   ./tests/e2e/test_container_leap16.sh
+  ```
+- **How to run openSUSE Tumbleweed container tests**:
+  ```bash
+  ./tests/e2e/test_container_tumbleweed.sh
   ```

--- a/tests/e2e/Containerfile
+++ b/tests/e2e/Containerfile
@@ -1,0 +1,15 @@
+FROM registry.opensuse.org/opensuse/leap:16.0
+
+# Enable debug repositories and install dependencies
+RUN zypper modifyrepo -e openSUSE:repo-oss-debug && \
+    zypper ref && \
+    zypper -n install -y which file go1.26 elfutils make gcc-c++ libcap-progs \
+    bzip2 bzip2-debuginfo \
+    gzip gzip-debuginfo \
+    gmp-devel libgmp10-debuginfo \
+    cpupower cpupower-debuginfo \
+    squid squid-debuginfo \
+    curl && \
+    zypper clean -a
+
+WORKDIR /workspace

--- a/tests/e2e/Containerfile
+++ b/tests/e2e/Containerfile
@@ -1,14 +1,24 @@
-FROM registry.opensuse.org/opensuse/leap:16.0
+ARG BASE_IMAGE=registry.opensuse.org/opensuse/leap:16.0
+FROM $BASE_IMAGE
 
-# Enable debug repositories and install dependencies
-RUN zypper modifyrepo -e openSUSE:repo-oss-debug && \
-    zypper ref && \
-    zypper -n install -y which file go1.26 elfutils make gcc-c++ libcap-progs \
+ARG DISTRO_CODENAME=leap16
+
+# Setup debug repositories based on distro
+RUN if [ "$DISTRO_CODENAME" = "leap16" ]; then \
+        zypper modifyrepo -e openSUSE:repo-oss-debug || zypper ar -f http://download.opensuse.org/debug/distribution/leap/16.0/repo/oss/x86_64 repo-oss-debug; \
+    elif [ "$DISTRO_CODENAME" = "tumbleweed" ]; then \
+        zypper modifyrepo -e repo-debug || zypper modifyrepo -e openSUSE:repo-oss-debug || zypper ar -f http://download.opensuse.org/debug/tumbleweed/repo/oss/ repo-debug; \
+    fi
+
+# Refresh and install required packages
+RUN zypper ref && \
+    zypper -n install -y which file gawk go1.26 elfutils make gcc-c++ libcap-progs \
     bzip2 bzip2-debuginfo \
     gzip gzip-debuginfo \
     gmp-devel libgmp10-debuginfo \
     cpupower cpupower-debuginfo \
     squid squid-debuginfo \
+    nginx nginx-debuginfo nginx-module-echo nginx-module-echo-debuginfo \
     curl && \
     zypper clean -a
 

--- a/tests/e2e/run_all_container_tests.sh
+++ b/tests/e2e/run_all_container_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "===================================================="
+echo "=== NOW RUNNING ENVIRONMENT INSIDE CONTAINER ==="
+echo "===================================================="
+
+echo "--- Copying workspace to avoid host file ownership pollution ---"
+rm -rf /workspace
+cp -r /host_workspace /workspace
+cd /workspace
+
+echo "--- Building funkoverage ---"
+./build.sh
+
+echo "--- Adding funkoverage to PATH ---"
+export PATH="/workspace:$PATH"
+
+echo "--- Running test_bzip2.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_bzip2.sh
+
+echo "--- Running test_gzip.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_gzip.sh
+
+echo "--- Running test_gmp.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_gmp.sh
+
+echo "--- Running test_cpupower.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_cpupower.sh
+
+echo "--- Running test_openssl.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_openssl.sh
+
+echo "--- Running test_squid.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_squid.sh
+
+echo "--- Running test_nginx_dlopen.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_nginx_dlopen.sh
+
+echo "===================================================="
+echo "=== ALL E2E CONTAINER TESTS SUCCEEDED ==="
+echo "===================================================="

--- a/tests/e2e/test_container_leap16.sh
+++ b/tests/e2e/test_container_leap16.sh
@@ -9,28 +9,23 @@ if ! command -v podman >/dev/null 2>&1; then
     RUNTIME="docker"
 fi
 
-# We use a temporary directory inside the container to avoid polluting the host workspace
-# but we map the current directory to copy from it.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "--- Building Container Image (caching packages) ---"
+sudo $RUNTIME build -t leap16-e2e -f "$SCRIPT_DIR/Containerfile" "$WORKSPACE_DIR"
+
+echo "--- Running Tests inside Container ---"
 sudo $RUNTIME run --rm --privileged --pid=host \
-    -v "$PWD:/host_workspace:ro" \
+    -v "$WORKSPACE_DIR:/host_workspace:ro" \
     -v /sys/kernel/btf:/sys/kernel/btf:ro \
     -v /sys/kernel/tracing:/sys/kernel/tracing \
     -v /sys/kernel/debug:/sys/kernel/debug \
-    registry.opensuse.org/opensuse/leap:16.0 bash -c '
+    leap16-e2e bash -c '
 set -euo pipefail
 
-echo "--- Setting up repos and installing dependencies ---"
-zypper modifyrepo -e openSUSE:repo-oss-debug
-zypper ref
-zypper -n install which file go1.26 elfutils make gcc-c++ libcap-progs \
-    bzip2 bzip2-debuginfo \
-    gzip gzip-debuginfo \
-    gmp-devel libgmp10-debuginfo \
-    cpupower cpupower-debuginfo \
-    squid squid-debuginfo \
-    curl
-
-echo "--- Copying workspace ---"
+echo "--- Copying workspace to avoid host file ownership pollution ---"
+rm -rf /workspace
 cp -r /host_workspace /workspace
 cd /workspace
 
@@ -58,5 +53,5 @@ bash tests/e2e/test_openssl.sh
 echo "--- Running test_squid.sh ---"
 bash tests/e2e/test_squid.sh
 
-echo "--- Success ---"
+echo "--- All Leap 16.0 Container E2E Tests Succeeded ---"
 '

--- a/tests/e2e/test_container_leap16.sh
+++ b/tests/e2e/test_container_leap16.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== Running Leap 16.0 Container E2E Test ==="
+
+# Define the container runtime
+RUNTIME="podman"
+if ! command -v podman >/dev/null 2>&1; then
+    RUNTIME="docker"
+fi
+
+# We use a temporary directory inside the container to avoid polluting the host workspace
+# but we map the current directory to copy from it.
+sudo $RUNTIME run --rm --privileged --pid=host \
+    -v "$PWD:/host_workspace:ro" \
+    -v /sys/kernel/btf:/sys/kernel/btf:ro \
+    -v /sys/kernel/tracing:/sys/kernel/tracing \
+    -v /sys/kernel/debug:/sys/kernel/debug \
+    registry.opensuse.org/opensuse/leap:16.0 bash -c '
+set -euo pipefail
+
+echo "--- Setting up repos and installing dependencies ---"
+zypper modifyrepo -e openSUSE:repo-oss-debug
+zypper ref
+zypper -n install which file go1.26 elfutils make gcc-c++ bzip2 bzip2-debuginfo libcap-progs
+
+echo "--- Copying workspace ---"
+cp -r /host_workspace /workspace
+cd /workspace
+
+echo "--- Building funkoverage ---"
+./build.sh
+
+echo "--- Adding funkoverage to PATH ---"
+export PATH="/workspace:$PATH"
+
+echo "--- Running test_bzip2.sh ---"
+bash tests/e2e/test_bzip2.sh
+
+echo "--- Success ---"
+'

--- a/tests/e2e/test_container_leap16.sh
+++ b/tests/e2e/test_container_leap16.sh
@@ -22,7 +22,13 @@ set -euo pipefail
 echo "--- Setting up repos and installing dependencies ---"
 zypper modifyrepo -e openSUSE:repo-oss-debug
 zypper ref
-zypper -n install which file go1.26 elfutils make gcc-c++ bzip2 bzip2-debuginfo libcap-progs
+zypper -n install which file go1.26 elfutils make gcc-c++ libcap-progs \
+    bzip2 bzip2-debuginfo \
+    gzip gzip-debuginfo \
+    gmp-devel libgmp10-debuginfo \
+    cpupower cpupower-debuginfo \
+    squid squid-debuginfo \
+    curl
 
 echo "--- Copying workspace ---"
 cp -r /host_workspace /workspace
@@ -36,6 +42,21 @@ export PATH="/workspace:$PATH"
 
 echo "--- Running test_bzip2.sh ---"
 bash tests/e2e/test_bzip2.sh
+
+echo "--- Running test_gzip.sh ---"
+bash tests/e2e/test_gzip.sh
+
+echo "--- Running test_gmp.sh ---"
+bash tests/e2e/test_gmp.sh
+
+echo "--- Running test_cpupower.sh ---"
+bash tests/e2e/test_cpupower.sh
+
+echo "--- Running test_openssl.sh ---"
+bash tests/e2e/test_openssl.sh
+
+echo "--- Running test_squid.sh ---"
+bash tests/e2e/test_squid.sh
 
 echo "--- Success ---"
 '

--- a/tests/e2e/test_container_leap16.sh
+++ b/tests/e2e/test_container_leap16.sh
@@ -24,6 +24,10 @@ sudo $RUNTIME run --rm --privileged --pid=host \
     leap16-e2e bash -c '
 set -euo pipefail
 
+echo "===================================================="
+echo "=== NOW RUNNING ENVIRONMENT INSIDE CONTAINER ==="
+echo "===================================================="
+
 echo "--- Copying workspace to avoid host file ownership pollution ---"
 rm -rf /workspace
 cp -r /host_workspace /workspace
@@ -35,22 +39,22 @@ echo "--- Building funkoverage ---"
 echo "--- Adding funkoverage to PATH ---"
 export PATH="/workspace:$PATH"
 
-echo "--- Running test_bzip2.sh ---"
+echo "--- Running test_bzip2.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_bzip2.sh
 
-echo "--- Running test_gzip.sh ---"
+echo "--- Running test_gzip.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_gzip.sh
 
-echo "--- Running test_gmp.sh ---"
+echo "--- Running test_gmp.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_gmp.sh
 
-echo "--- Running test_cpupower.sh ---"
+echo "--- Running test_cpupower.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_cpupower.sh
 
-echo "--- Running test_openssl.sh ---"
+echo "--- Running test_openssl.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_openssl.sh
 
-echo "--- Running test_squid.sh ---"
+echo "--- Running test_squid.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_squid.sh
 
 echo "--- All Leap 16.0 Container E2E Tests Succeeded ---"

--- a/tests/e2e/test_container_tumbleweed.sh
+++ b/tests/e2e/test_container_tumbleweed.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "=== Running Leap 16.0 Container E2E Test ==="
+echo "=== Running Tumbleweed Container E2E Test ==="
 
 # Define the container runtime
 RUNTIME="podman"
@@ -12,11 +12,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-echo "--- Building Container Image (Leap 16.0) ---"
+echo "--- Building Container Image (Tumbleweed) ---"
 sudo $RUNTIME build \
-    -t leap16-e2e \
-    --build-arg BASE_IMAGE=registry.opensuse.org/opensuse/leap:16.0 \
-    --build-arg DISTRO_CODENAME=leap16 \
+    -t tumbleweed-e2e \
+    --build-arg BASE_IMAGE=registry.opensuse.org/opensuse/tumbleweed:latest \
+    --build-arg DISTRO_CODENAME=tumbleweed \
     -f "$SCRIPT_DIR/Containerfile" "$WORKSPACE_DIR"
 
 echo "--- Running Tests inside Container ---"
@@ -25,4 +25,4 @@ sudo $RUNTIME run --rm --privileged --pid=host \
     -v /sys/kernel/btf:/sys/kernel/btf:ro \
     -v /sys/kernel/tracing:/sys/kernel/tracing \
     -v /sys/kernel/debug:/sys/kernel/debug \
-    leap16-e2e /host_workspace/tests/e2e/run_all_container_tests.sh
+    tumbleweed-e2e /host_workspace/tests/e2e/run_all_container_tests.sh


### PR DESCRIPTION
## Description
This PR introduces clean, reproducible, and fully containerized End-to-End (E2E) testing environments for `funkoverage`. It supports parallel runs on both **openSUSE Leap 16.0** and **openSUSE Tumbleweed** using a shared, cached base image setup.

To achieve maximum DRYness and reuse:
1. **`tests/e2e/Containerfile`**: A unified container blueprint using build arguments (`BASE_IMAGE`, `DISTRO_CODENAME`) to dynamically configure the target distro and pull all necessary dependencies and debug symbol packages.
2. **`tests/e2e/run_all_container_tests.sh`**: A single, clean, shared test execution script mounted inside the container, compiling the framework and sequentially exercising 7 complete system E2E tests:
   - `bzip2` (basic life-cycle, CLI coverage)
   - `gzip` (script wrappers, recursive directories)
   - `gmp` (in-place local library debug merges)
   - `cpupower` (`.gnu_debuglink` fallback resolution)
   - `openssl` (multi-library JIT tracing)
   - `squid` (C++ demangling, daemon forks)
   - `nginx` (dlopen JIT module tracing)

## Benefits
- **Caching**: Package installation (using `zypper`) is fully cached in the container layers, cutting repetitive local run times down to seconds.
- **Isolation**: Prevents root-owned build artifact pollution on the host by compiling and testing in a safe overlay filesystem.
- **Portability**: This container setup can easily run identically locally or inside GitHub Actions / CI virtual machines without manual setup of debug repositories on the runner host.

## Documentation
An updated `tests/README.md` has been added, explaining each E2E test's coverage, its required packages, and exact commands for running the unit, sample, and containerized test suites.
