### PR TITLE
Forward signals to shim child and relay sd_notify (fix #143)

### DIFF
--- a/cmd/shim_binary/main.go
+++ b/cmd/shim_binary/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -119,11 +120,17 @@ func runWithTracing(realBin string) (exitCode int, err error) {
 	}()
 	cleanups = append(cleanups, func() { pipeW.Close() })
 
+	notifyProxy, notifyCleanup, err := startNotifyRelay()
+	if err != nil {
+		return 1, err
+	}
+	cleanups = append(cleanups, notifyCleanup)
+
 	shimExe, _ := os.Executable()
 	childCmd := exec.Command(shimExe, os.Args[1:]...)
 	childCmd.Stdin, childCmd.Stdout, childCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	childCmd.ExtraFiles = []*os.File{pipeR}
-	childCmd.Env = buildChildEnv(realBin)
+	childCmd.Env = buildChildEnv(realBin, notifyProxy)
 
 	if err := childCmd.Start(); err != nil {
 		pipeR.Close()
@@ -153,12 +160,48 @@ func runWithTracing(realBin string) (exitCode int, err error) {
 	}
 	pipeW.Close()
 
-	state, _ := childCmd.Process.Wait()
+	state := waitForwardingSignals(childCmd.Process)
 	if state != nil {
 		exitCode = state.ExitCode()
 	}
 	_ = tracer.Stop()
 	return exitCode, nil
+}
+
+// waitForwardingSignals blocks until proc exits, relaying any termination
+// signal the shim itself receives to proc first. Without this, the shim
+// parent (which has no signal handler otherwise) would die immediately on
+// SIGTERM by OS default action, leaving proc running and its resources
+// (e.g. a bound socket) unreleased — breaking systemd restarts, which move
+// on as soon as the tracked MainPID (this parent) exits.
+func waitForwardingSignals(proc *os.Process) *os.ProcessState {
+	// No explicit signal list: forward everything. SIGUSR1/SIGUSR2 default
+	// to terminating the process just like SIGTERM does, and daemons vary
+	// widely in which signals they treat as meaningful (nginx alone reacts
+	// to HUP, QUIT, USR1, USR2, WINCH) — an allowlist here just relocates
+	// issue #143's bug to whichever signal wasn't on the list. Buffered
+	// beyond 1 in case more than one signal arrives before a select
+	// iteration drains it. SIGKILL/SIGSTOP can't be caught regardless, and
+	// Go's runtime already excludes its own SIGURG preemption signal from
+	// an argument-less Notify.
+	sigCh := make(chan os.Signal, 8)
+	signal.Notify(sigCh)
+	defer signal.Stop(sigCh)
+
+	done := make(chan *os.ProcessState, 1)
+	go func() {
+		state, _ := proc.Wait()
+		done <- state
+	}()
+
+	for {
+		select {
+		case sig := <-sigCh:
+			_ = proc.Signal(sig)
+		case state := <-done:
+			return state
+		}
+	}
 }
 
 func calledLogPath(dir, realBin string) string {
@@ -168,13 +211,20 @@ func calledLogPath(dir, realBin string) string {
 	return filepath.Join(dir, name)
 }
 
-func buildChildEnv(realBin string) []string {
+// buildChildEnv builds the child's environment. notifyProxy, when non-empty,
+// overrides NOTIFY_SOCKET so the child's sd_notify() calls reach
+// startNotifyRelay instead of the real systemd socket directly.
+func buildChildEnv(realBin, notifyProxy string) []string {
 	arg0 := os.Getenv(arg0EnvVar)
 	if arg0 == "" {
 		arg0 = os.Args[0]
 	}
 	activeEnvVar := activeEnvPrefix + envSafeName(filepath.Base(realBin))
-	env := cleanEnv(activeEnvVar)
+	skip := []string{activeEnvVar}
+	if notifyProxy != "" {
+		skip = append(skip, notifySocketEnvVar)
+	}
+	env := cleanEnv(skip...)
 	env = append(env,
 		childEnvVar+"=1",
 		waitFdEnvVar+"=3",
@@ -184,6 +234,9 @@ func buildChildEnv(realBin string) []string {
 	)
 	if v := os.Getenv("LOG_DIR"); v != "" {
 		env = append(env, "LOG_DIR="+v)
+	}
+	if notifyProxy != "" {
+		env = append(env, notifySocketEnvVar+"="+notifyProxy)
 	}
 	return env
 }

--- a/cmd/shim_binary/main_test.go
+++ b/cmd/shim_binary/main_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"funkoverage/internal/funkutil"
 )
@@ -61,7 +67,7 @@ func TestBuildChildEnv(t *testing.T) {
 	t.Setenv("LOG_DIR", tmpDir)
 	t.Setenv(arg0EnvVar, "custom-arg0")
 
-	env := buildChildEnv("/usr/bin/mybin")
+	env := buildChildEnv("/usr/bin/mybin", "")
 
 	var foundChild, foundWait, foundArg0, foundActive, foundSafe, foundLog bool
 	for _, kv := range env {
@@ -96,6 +102,106 @@ func TestBuildChildEnv(t *testing.T) {
 
 	if !foundChild || !foundWait || !foundArg0 || !foundActive || !foundSafe || !foundLog {
 		t.Errorf("buildChildEnv missing expected environment definitions")
+	}
+}
+
+func TestBuildChildEnv_NotifyProxyOverride(t *testing.T) {
+	t.Setenv("SAFE_BIN_DIR", t.TempDir())
+	t.Setenv(notifySocketEnvVar, "/run/systemd/notify")
+
+	env := buildChildEnv("/usr/bin/mybin", "/tmp/funkoverage-notify-123.sock")
+
+	var got string
+	var count int
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		if k == notifySocketEnvVar {
+			got = v
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one %s entry, got %d", notifySocketEnvVar, count)
+	}
+	if got != "/tmp/funkoverage-notify-123.sock" {
+		t.Errorf("%s = %q, want proxy path", notifySocketEnvVar, got)
+	}
+}
+
+// signalHelperTable maps a name usable on the command line/env to the
+// syscall.Signal it identifies, for TestHelperSignalChild and
+// TestWaitForwardingSignals_ForwardsSignalToChild.
+var signalHelperTable = map[string]syscall.Signal{
+	"TERM": syscall.SIGTERM,
+	"USR1": syscall.SIGUSR1,
+}
+
+// TestHelperSignalChild is not a real test: it's spawned as a subprocess by
+// TestWaitForwardingSignals_ForwardsSignalToChild to act as a child that
+// traps and reports whichever signal FUNKOVERAGE_TEST_SIGNAL names. A shell
+// "trap ...; sleep N" fixture doesn't work here — bash defers running the
+// trap's `exit` until its blocking `sleep` child returns, which defeats the
+// point of testing prompt delivery.
+func TestHelperSignalChild(t *testing.T) {
+	name := os.Getenv("FUNKOVERAGE_TEST_SIGNAL")
+	sig, ok := signalHelperTable[name]
+	if !ok {
+		t.Skip("helper process, not a real test")
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, sig)
+	<-sigCh
+	fmt.Println("GOT_" + name)
+	os.Exit(0)
+}
+
+// TestWaitForwardingSignals_ForwardsSignalToChild verifies the shim relays
+// real, catchable signals to the child instead of the child either being
+// left unsignalled (issue #143's socket-not-released bug) or SIGKILLed
+// (losing any graceful-shutdown output, as reported for tcpdump). Covers
+// both a signal that was already on the old hand-picked allowlist (TERM)
+// and one that wasn't (USR1) — catch-all forwarding means both work the
+// same way, with no per-signal list to fall out of date.
+func TestWaitForwardingSignals_ForwardsSignalToChild(t *testing.T) {
+	for name, sig := range signalHelperTable {
+		t.Run(name, func(t *testing.T) {
+			child := exec.Command(os.Args[0], "-test.run=^TestHelperSignalChild$")
+			child.Env = append(os.Environ(), "FUNKOVERAGE_TEST_SIGNAL="+name)
+			var out bytes.Buffer
+			child.Stdout = &out
+			if err := child.Start(); err != nil {
+				t.Fatalf("start child: %v", err)
+			}
+
+			done := make(chan *os.ProcessState, 1)
+			go func() { done <- waitForwardingSignals(child.Process) }()
+
+			// Retry self-signalling rather than sleeping a fixed guess:
+			// closes the (unavoidable) race between this goroutine starting
+			// and waitForwardingSignals installing its signal.Notify.
+			ticker := time.NewTicker(20 * time.Millisecond)
+			defer ticker.Stop()
+			deadline := time.After(5 * time.Second)
+			var state *os.ProcessState
+		loop:
+			for {
+				select {
+				case state = <-done:
+					break loop
+				case <-ticker.C:
+					_ = syscall.Kill(os.Getpid(), sig)
+				case <-deadline:
+					t.Fatal("waitForwardingSignals did not return after child exit")
+				}
+			}
+
+			if state == nil || !state.Success() {
+				t.Errorf("unexpected child exit state: %v", state)
+			}
+			if !strings.Contains(out.String(), "GOT_"+name) {
+				t.Errorf("child never ran its own %s trap (would mean SIGKILL, not forwarding); output: %q", name, out.String())
+			}
+		})
 	}
 }
 

--- a/cmd/shim_binary/notify.go
+++ b/cmd/shim_binary/notify.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const notifySocketEnvVar = "NOTIFY_SOCKET"
+
+// notifySocketAddr translates systemd's NOTIFY_SOCKET convention into a
+// net.UnixAddr: a leading '@' denotes the abstract namespace, represented on
+// Linux by a leading NUL byte — net.Dial/Listen don't do this translation
+// automatically.
+func notifySocketAddr(raw string) *net.UnixAddr {
+	name := raw
+	if strings.HasPrefix(name, "@") {
+		name = "\x00" + name[1:]
+	}
+	return &net.UnixAddr{Name: name, Net: "unixgram"}
+}
+
+// startNotifyRelay proxies sd_notify datagrams from the child to the real
+// systemd NOTIFY_SOCKET. This is needed because systemd's default
+// NotifyAccess=main only trusts datagrams from the MainPID it tracks — the
+// shim parent — while the real daemon runs as the shim's child under a
+// different PID (see childMain's syscall.Exec), so its own sd_notify()
+// calls would otherwise be silently dropped. Returns ("", no-op cleanup,
+// nil) if NOTIFY_SOCKET isn't set (not a Type=notify service).
+func startNotifyRelay() (proxyPath string, cleanup func(), err error) {
+	raw := os.Getenv(notifySocketEnvVar)
+	if raw == "" {
+		return "", func() {}, nil
+	}
+
+	proxyPath = filepath.Join(os.TempDir(), fmt.Sprintf("funkoverage-notify-%d.sock", os.Getpid()))
+	_ = os.Remove(proxyPath)
+	proxy, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: proxyPath, Net: "unixgram"})
+	if err != nil {
+		return "", nil, fmt.Errorf("listen notify proxy: %w", err)
+	}
+
+	real, err := net.DialUnix("unixgram", nil, notifySocketAddr(raw))
+	if err != nil {
+		proxy.Close()
+		os.Remove(proxyPath)
+		return "", nil, fmt.Errorf("dial real notify socket %q: %w", raw, err)
+	}
+
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := proxy.Read(buf)
+			if err != nil {
+				return
+			}
+			_, _ = real.Write(buf[:n])
+		}
+	}()
+
+	cleanup = func() {
+		proxy.Close()
+		real.Close()
+		os.Remove(proxyPath)
+	}
+	return proxyPath, cleanup, nil
+}

--- a/cmd/shim_binary/notify_test.go
+++ b/cmd/shim_binary/notify_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNotifySocketAddr(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"/run/systemd/notify", "/run/systemd/notify"},
+		{"@/run/systemd/notify/abc", "\x00/run/systemd/notify/abc"},
+	}
+	for _, tc := range cases {
+		got := notifySocketAddr(tc.raw)
+		if got.Name != tc.want {
+			t.Errorf("notifySocketAddr(%q).Name = %q, want %q", tc.raw, got.Name, tc.want)
+		}
+		if got.Net != "unixgram" {
+			t.Errorf("notifySocketAddr(%q).Net = %q, want unixgram", tc.raw, got.Net)
+		}
+	}
+}
+
+func TestStartNotifyRelay_NoOpWithoutEnv(t *testing.T) {
+	t.Setenv(notifySocketEnvVar, "")
+
+	proxyPath, cleanup, err := startNotifyRelay()
+	if err != nil || proxyPath != "" {
+		t.Fatalf("expected no-op, got proxyPath=%q err=%v", proxyPath, err)
+	}
+	cleanup() // must be safe to call
+}
+
+func TestStartNotifyRelay_ForwardsDatagram(t *testing.T) {
+	realPath := filepath.Join(t.TempDir(), "systemd-notify.sock")
+	real, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: realPath, Net: "unixgram"})
+	if err != nil {
+		t.Fatalf("listen fake systemd socket: %v", err)
+	}
+	defer real.Close()
+
+	t.Setenv(notifySocketEnvVar, realPath)
+
+	proxyPath, cleanup, err := startNotifyRelay()
+	if err != nil {
+		t.Fatalf("startNotifyRelay: %v", err)
+	}
+	if proxyPath == "" {
+		t.Fatal("startNotifyRelay returned empty proxy path with NOTIFY_SOCKET set")
+	}
+	if _, err := os.Stat(proxyPath); err != nil {
+		t.Fatalf("proxy socket file missing: %v", err)
+	}
+
+	client, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: proxyPath, Net: "unixgram"})
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer client.Close()
+	if _, err := client.Write([]byte("READY=1")); err != nil {
+		t.Fatalf("write to proxy: %v", err)
+	}
+
+	_ = real.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, err := real.Read(buf)
+	if err != nil {
+		t.Fatalf("read from fake systemd socket: %v", err)
+	}
+	if got := string(buf[:n]); got != "READY=1" {
+		t.Errorf("relayed datagram = %q, want READY=1", got)
+	}
+
+	cleanup()
+	if _, err := os.Stat(proxyPath); !os.IsNotExist(err) {
+		t.Errorf("proxy socket file not removed after cleanup: err=%v", err)
+	}
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -251,6 +251,31 @@ Library discovery: `ldd` output, minus glibc/runtime libs (libc, libm, libpthrea
              (idempotent via sync.Once)
 ```
 
+### Signal forwarding and sd_notify relay
+
+The parent catches every signal it can (`waitForwardingSignals`, a bare
+`signal.Notify(sigCh)` with no filter) and relays whatever it receives to
+the child, then keeps blocking until the child actually exits before
+returning. No hand-picked allowlist: SIGUSR1/SIGUSR2 default to terminating
+the process just like SIGTERM does, and daemons vary widely in which
+signals they treat as meaningful (nginx alone reacts to HUP, QUIT, USR1,
+USR2, WINCH) — a fixed list just relocates issue #143's bug to whichever
+signal wasn't on it. Without any handler, the parent dies immediately on
+the OS default action, leaving the child (the real daemon) running
+unsignalled — under systemd this means the tracked MainPID (the parent)
+exits before the child releases its resources (e.g. a bound socket), so a
+`systemctl restart` races the old instance and can fail to bind (issue
+#143).
+
+If `NOTIFY_SOCKET` is set (a `Type=notify` systemd unit), the parent proxies
+it (`startNotifyRelay`) rather than passing it through unchanged: systemd's
+default `NotifyAccess=main` only trusts `sd_notify` datagrams from the
+MainPID it's tracking, which is the parent — but the real daemon runs as
+the *child* (a different PID, via `syscall.Exec` in `childMain`). The parent
+points the child at a private unix datagram socket instead and forwards
+every datagram it receives to the real socket itself, so the kernel-attached
+sender credentials on the relayed datagram are the parent's.
+
 ## Permissions model
 
 - **Install**: must run as root (moves files in `/usr/bin`, runs `setcap`)
@@ -273,6 +298,7 @@ Library discovery: `ldd` output, minus glibc/runtime libs (libc, libm, libpthrea
 │   ├── templates/            # *.html for report rendering
 │   └── shim_binary/
 │       ├── main.go           # shim main + child fork dance
+│       ├── notify.go         # sd_notify relay (Type=notify units)
 │       ├── tracer.go         # cilium/ebpf wiring, ringbuf reader
 │       ├── tracer_{x86,arm64}_bpfel.{go,o}  # bpf2go-generated bindings
 │       └── bpf/

--- a/tests/e2e/run_all_container_tests.sh
+++ b/tests/e2e/run_all_container_tests.sh
@@ -37,6 +37,9 @@ bash tests/e2e/test_squid.sh
 echo "--- Running test_nginx_dlopen.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_nginx_dlopen.sh
 
+echo "--- Running test_signal_and_notify_relay.sh [INSIDE CONTAINER] ---"
+bash tests/e2e/test_signal_and_notify_relay.sh
+
 echo "--- Running test_duplicate_library_symlink.sh [INSIDE CONTAINER] ---"
 bash tests/e2e/test_duplicate_library_symlink.sh
 

--- a/tests/e2e/test_signal_and_notify_relay.sh
+++ b/tests/e2e/test_signal_and_notify_relay.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# E2E test: funkoverage shim signal forwarding + sd_notify relay (issue #143)
+#
+# Reproduces the systemd restart bug (parent shim dies on SIGTERM without
+# telling the child, so the child keeps holding its socket after systemd
+# already considers the unit stopped) using a tiny fixture daemon instead of
+# sshd — avoids host keys / systemd-unit setup while isolating exactly the
+# shim's process-supervision bug. Also verifies sd_notify(READY=1) reaches a
+# stand-in "systemd" socket, since systemd's default NotifyAccess=main only
+# trusts datagrams from the MainPID it tracks (the shim parent), not the
+# child that actually runs the real daemon.
+#
+# Run as root on openSUSE with funkoverage in PATH. Needs `go` in PATH to
+# build the fixture.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib_test_helpers.sh"
+
+BINARY=""
+WORKDIR=""
+PORT=18199
+SHIM_PID=""
+
+cleanup() {
+    [[ -n "$SHIM_PID" ]] && kill "$SHIM_PID" 2>/dev/null || true
+    pkill -f notifydaemon 2>/dev/null || true
+    [[ -n "$BINARY" ]] && funkoverage uninstall "$BINARY" 2>/dev/null || true
+    [[ -n "$WORKDIR" ]] && rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# --- Prerequisites ---
+header "Prerequisites"
+require_root
+require_funkoverage
+command -v go >/dev/null 2>&1 || fail "go not in PATH (needed to build the fixture)"
+
+WORKDIR=$(mktemp -d /tmp/funkoverage_notifydaemon_XXXX)
+BINARY="$WORKDIR/notifydaemon"
+info "Building fixture daemon"
+(cd "$SCRIPT_DIR/../.." && go build -o "$BINARY" ./tests/sample/notifydaemon)
+require_debug_symbols "$BINARY"
+pass "notifydaemon fixture built with debug symbols"
+
+clean_coverage_data
+install_shim --no-libs "$BINARY"
+pass "Shim installed"
+
+# --- Fix A: signal forwarding + socket release timing ---
+header "Signal forwarding (issue #143 restart race)"
+
+"$BINARY" "$PORT" > "$WORKDIR/daemon_output.txt" 2>&1 &
+SHIM_PID=$!
+
+info "Waiting for fixture to bind port $PORT..."
+for i in $(seq 1 15); do
+    ss -ltn 2>/dev/null | grep -q ":$PORT " && break
+    [[ $i -eq 15 ]] && fail "notifydaemon did not bind port $PORT in 15s"
+    sleep 1
+done
+pass "Port $PORT bound"
+
+# Signal only the shim's own PID, mirroring systemd signalling just the
+# tracked MainPID (not the whole cgroup) on `systemctl restart`.
+kill -TERM "$SHIM_PID"
+wait "$SHIM_PID" 2>/dev/null || true
+pass "Shim (parent, tracked MainPID) exited"
+
+if ss -ltn 2>/dev/null | grep -q ":$PORT "; then
+    fail "port $PORT still bound after shim exited — child was not signalled/waited on"
+fi
+pass "Port released by the time the shim exited"
+
+grep -q "EXITING" "$WORKDIR/daemon_output.txt" \
+    || fail "child never ran its own SIGTERM handling — means it wasn't sent a real, catchable signal"
+pass "Child received a real signal and shut down on its own (not SIGKILLed)"
+
+SHIM_PID=""
+
+# --- Fix B: sd_notify relay ---
+header "sd_notify relay (Type=notify support)"
+
+NOTIFY_SOCK="$WORKDIR/fake-systemd-notify.sock"
+"$BINARY" -notify-listener "$NOTIFY_SOCK" > "$WORKDIR/notify_output.txt" 2>&1 &
+LISTENER_PID=$!
+sleep 0.5
+
+NOTIFY_SOCKET="$NOTIFY_SOCK" "$BINARY" "$((PORT + 1))" > "$WORKDIR/daemon2_output.txt" 2>&1 &
+SHIM_PID=$!
+
+info "Waiting for sd_notify relay..."
+for i in $(seq 1 10); do
+    kill -0 "$LISTENER_PID" 2>/dev/null || break
+    [[ $i -eq 10 ]] && fail "sd_notify READY=1 never reached the fake systemd socket"
+    sleep 1
+done
+wait "$LISTENER_PID" 2>/dev/null || true
+
+grep -q "READY=1" "$WORKDIR/notify_output.txt" \
+    || fail "fake systemd socket did not receive READY=1"
+pass "sd_notify READY=1 relayed to the real NOTIFY_SOCKET"
+
+kill -TERM "$SHIM_PID" 2>/dev/null || true
+wait "$SHIM_PID" 2>/dev/null || true
+SHIM_PID=""
+
+# --- Uninstall ---
+header "Uninstall"
+uninstall_and_verify "$BINARY"
+BINARY="" # prevent double-uninstall in trap
+
+echo ""
+echo -e "${GREEN}ALL TESTS PASSED${NC} (shim signal forwarding + notify relay)"

--- a/tests/sample/notifydaemon/main.go
+++ b/tests/sample/notifydaemon/main.go
@@ -1,0 +1,78 @@
+// notifydaemon is a minimal fixture daemon for the e2e shim signal/notify
+// tests: it binds a TCP port, optionally sends READY=1 to $NOTIFY_SOCKET,
+// then blocks until it receives SIGTERM/SIGINT, at which point it prints
+// EXITING and returns (releasing the port) — standing in for a real daemon
+// like sshd without needing host keys or a systemd unit.
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "-notify-listener" {
+		runNotifyListener(os.Args[2])
+		return
+	}
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: notifydaemon <port> | notifydaemon -notify-listener <socket-path>")
+		os.Exit(1)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:"+os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "listen:", err)
+		os.Exit(1)
+	}
+	defer ln.Close()
+
+	if sock := os.Getenv("NOTIFY_SOCKET"); sock != "" {
+		notify(sock, "READY=1")
+	}
+	fmt.Println("READY")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	<-sigCh
+	fmt.Println("EXITING")
+}
+
+// runNotifyListener stands in for systemd's own NOTIFY_SOCKET: reads one
+// datagram and prints it, so the e2e test can verify the shim's relay
+// without needing a real systemd unit.
+func runNotifyListener(path string) {
+	_ = os.Remove(path)
+	ln, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "listen notify:", err)
+		os.Exit(1)
+	}
+	defer ln.Close()
+	buf := make([]byte, 4096)
+	n, err := ln.Read(buf)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read notify:", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(buf[:n]))
+}
+
+// notify sends msg to a systemd-style NOTIFY_SOCKET, translating the
+// leading '@' abstract-namespace convention to the actual leading NUL byte.
+func notify(rawSock, msg string) {
+	name := rawSock
+	if strings.HasPrefix(name, "@") {
+		name = "\x00" + name[1:]
+	}
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: name, Net: "unixgram"})
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	_, _ = conn.Write([]byte(msg))
+}


### PR DESCRIPTION
## Summary

Fixes #143. The shim installed no signal handlers at all:

- **Restart race**: SIGTERM killed the shim parent immediately via the OS default action, leaving the real daemon (child) running orphaned and its socket still held. systemd's `MainPID` (the parent) exited before the child released anything, so `systemctl restart` raced the old instance and failed to bind (`Cannot bind any address`). Also explains bzoltan1's comment — the child never received a real, catchable signal, so tcpdump lost its shutdown summary.
- **Type=notify daemons couldn't start**: systemd's default `NotifyAccess=main` only trusts `sd_notify` datagrams from the tracked MainPID (the parent), but the real daemon runs as the shim's *child* under a different PID, so `sd_notify(READY=1)` was silently dropped — the reported workaround was a `Type=simple` systemd drop-in.

## Changes

- `waitForwardingSignals` (`cmd/shim_binary/main.go`): catches **every** signal (`signal.Notify(sigCh)`, no allowlist — SIGUSR1/SIGUSR2 default to terminate just like SIGTERM, and daemons vary in which signals matter, e.g. nginx uses HUP/QUIT/USR1/USR2/WINCH), relays it to the child, and blocks the parent's exit until the child actually terminates. Non-terminal signals (e.g. a reload) just get relayed and the parent keeps waiting — the loop only exits when `proc.Wait()` really returns.
- `startNotifyRelay` (`cmd/shim_binary/notify.go`): if `NOTIFY_SOCKET` is set, proxies it — creates a private socket for the child, forwards datagrams to the real systemd socket from the parent's own PID.
- `docs/design.md`: documents both invariants.

## Test plan

- [x] Unit tests: `TestWaitForwardingSignals_ForwardsSignalToChild` (table test over TERM + USR1, using a real subprocess helper — a shell `trap` fixture doesn't work since bash defers running the trap's `exit` until its blocking `sleep` child returns), `TestNotifySocketAddr`, `TestStartNotifyRelay_ForwardsDatagram`.
- [x] New e2e test `tests/e2e/test_signal_and_notify_relay.sh` + fixture `tests/sample/notifydaemon`, run as root on a real kernel (BTF, uprobe_multi) VM:
  - Confirmed it **reproduces the bug** against pre-fix code (`port still bound after shim exited`).
  - Confirmed it **passes** on this branch (port released, child logs `EXITING`, sd_notify `READY=1` relayed).
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean; added to `run_all_container_tests.sh`.